### PR TITLE
fix: export shared DOM nodes

### DIFF
--- a/easterEgg.js
+++ b/easterEgg.js
@@ -1,4 +1,4 @@
-import { player } from './script.js';
+import { player, text, goldText, healthText } from './script.js';
 import { eventEmitter } from './eventEmitter.js';
 
 export function pickTwo() {

--- a/fight.js
+++ b/fight.js
@@ -2,7 +2,7 @@ import { locations, monsterHealthText, monsterNameText } from './location.js';
 import { weapons, } from './item.js';
 import { eventEmitter, } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
-import { player, entityManager } from './script.js';
+import { player, entityManager, text, goldText, xpText, monsterStats, image } from './script.js';
 
 
 let fighting;
@@ -29,9 +29,8 @@ eventEmitter.on('goFight', () => {
   monsterNameText.innerText = enemyName;
   monsterHealthText.innerText = enemyHealth;
 
-  const monsterImage = document.getElementById('image');
-  monsterImage.src = fighting.imageUrl;
-  monsterImage.style.display = "block";
+  image.src = fighting.imageUrl;
+  image.style.display = "block";
 });
 eventEmitter.on('attack', () => {
   let enemyLevel = enemy.getComponent("level");
@@ -111,7 +110,7 @@ function getPlayerAttackValue(level) {
  * Updates the text to indicate the player dodged the attack.
 */
 eventEmitter.on('dodge', () => {
-  text.innerText = "You dodge the attack from the " + monsters[fighting].name + ".";
+  text.innerText = `You dodge the attack from the ${fighting.name}.`;
 });
 
 /**

--- a/location.js
+++ b/location.js
@@ -1,5 +1,5 @@
 import { eventEmitter } from './eventEmitter.js';
-import {  player, xpText, healthText, goldText } from './script.js';
+import { player, xpText, healthText, goldText, text, image, imageContainer, monsterStats } from './script.js';
 import { buyHealth, buyWeapon, sellWeapon } from './store.js';
 import { pickTwo, pickEight } from './easterEgg.js';
 export const monsterNameText = document.querySelector("#monsterName");
@@ -169,11 +169,9 @@ eventEmitter.on('update', (location) => {
   console.log("update called")
   if (location.image == false) {
     imageContainer.style.display = "none";
-    const image = document.getElementById("image");
     image.style.display = "none";
   } else if (location.image == true) {
     imageContainer.style.display = "block";
-    const image = document.getElementById("image");
     image.style.display = "block";
     image.src = location.imageUrl;
   }

--- a/script.js
+++ b/script.js
@@ -1,12 +1,14 @@
 import { eventEmitter } from './eventEmitter.js';
 import { nameComponent, healthComponent, levelComponent, imageUrlComponent, xpComponent, goldComponent, strengthComponent, intelligenceComponent, currentWeaponComponent, inventoryComponent } from './entityComponent.js';
 import { weapons } from './item.js';
-const text = document.querySelector("#text");
+
+export const text = document.querySelector("#text");
 export const xpText = document.querySelector("#xpText");
 export const healthText = document.querySelector("#healthText");
 export const goldText = document.querySelector("#goldText");
-
 export const image = document.querySelector("#image");
+export const monsterStats = document.querySelector("#monsterStats");
+export const imageContainer = document.querySelector("#imageContainer");
 
 // Entity
 export class Entity {

--- a/store.js
+++ b/store.js
@@ -1,4 +1,4 @@
-import { player } from './script.js';
+import { player, text } from './script.js';
 import { eventEmitter } from './eventEmitter.js';
 import { weapons } from './item.js';
 


### PR DESCRIPTION
## Summary
- export shared DOM elements from `script.js`
- import DOM references in modules instead of using implicit globals
- remove remaining global usage causing ReferenceErrors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be37b4b220832f9d2c0c8a2ec48f7f