### PR TITLE
Fix weapon sell logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,8 +143,12 @@ eventEmitter.on('weaponUp',() => {
 eventEmitter.on('weaponDown',() => {
   let weaponComp = player.getComponent('currentWeapon');
   let inventory = player.getComponent('inventory').items;
-  if (inventory.length > 1 && weaponComp.weaponIndex > 1) {
-    weaponComp.weaponIndex.shift;
+  if (inventory.length > 1 && weaponComp.weaponIndex > 0) {
+    inventory.pop();
+    weaponComp.weaponIndex--;
+    let newWeapon = weapons[weaponComp.weaponIndex].name;
+    text.innerText = "You now have a " + newWeapon + ".";
+    text.innerText += " In your inventory you have: " + inventory;
   } else {
     text.innerText = "You don't have any weapons in your inventory!";
   }


### PR DESCRIPTION
## Summary
- Fix weapon selling by decrementing weapon index and removing the last item from inventory.
- Allow re-equipping the first weapon when selling by adjusting boundary checks.
- Update inventory messages to display the current weapon after selling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be37c00d60832fb274db48da52de09