### PR TITLE
refactor: centralize DOM element references

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -1,4 +1,4 @@
-import { locations, monsterHealthText, monsterNameText } from './location.js';
+import { locations, monsterHealthText, monsterNameText, monsterStats } from './location.js';
 import { weapons, } from './item.js';
 import { eventEmitter, } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';

--- a/location.js
+++ b/location.js
@@ -6,6 +6,8 @@ export const monsterNameText = document.querySelector("#monsterName");
 export const monsterHealthText = document.querySelector("#monsterHealth");
 export const monsterText = document.querySelector("#monsterText");
 export const monsterHealthStat = document.querySelector("#monsterHealthStat");
+const imageContainer = document.getElementById('imageContainer');
+export const monsterStats = document.getElementById('monsterStats');
 
 function health() {
   let healthComponent = player.getComponent('health');


### PR DESCRIPTION
## Summary
- define reusable DOM constants for image and monster stat containers
- export `monsterStats` for modules needing access
- import new `monsterStats` reference in fight handler

## Testing
- `node --check location.js`
- `node --check fight.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be37baa654832fa310111c1c0ed285