### PR TITLE
Add settings and changelog screens

### DIFF
--- a/location.js
+++ b/location.js
@@ -133,6 +133,20 @@ export const locations = [
       text: "Welcome to CveCrwlr! Kill the stuff! Get the Levels! Beat the game!",
       imageUrl: "/imgs/openScreen.png",
       image: true
+    },
+    {
+      name: "settings",
+      "button text": ["Back"],
+      "button functions": [goHomeScreen],
+      text: "Settings are coming soon.",
+      image: false
+    },
+    {
+      name: "changelog",
+      "button text": ["Back"],
+      "button functions": [goHomeScreen],
+      text: "Changelog:\n- Added Settings and Changelog screens.",
+      image: false
     }
   ];
 
@@ -249,9 +263,11 @@ export function goPickCharacter() {
 }
 
 export function goSettings() {
-
+  eventEmitter.emit('update', (locations[11]) );
+  console.log("Settings function called");
 }
 
 export function goChangelog() {
-
+  eventEmitter.emit('update', (locations[12]) );
+  console.log("Changelog function called");
 }


### PR DESCRIPTION
## Summary
- Implement settings and changelog screens with navigation from the home menu
- Emit update events to show the new screens via goSettings and goChangelog

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68be3f937e70832fad4a1885f1bcb5b4