### PR TITLE
Align starting gold with UI and initialize update event

### DIFF
--- a/location.js
+++ b/location.js
@@ -163,8 +163,8 @@ function createButtons(location) {
   });
 }
   
-  // initialize buttons
-  createButtons(locations[9]);
+  // initialize UI
+  eventEmitter.emit('update', locations[9]);
   
 /**
  * Updates the UI based on the given location object.

--- a/script.js
+++ b/script.js
@@ -59,7 +59,7 @@ export let player = entityManager.createEntity({
   'health': new healthComponent(100),
   'level': new levelComponent(1),
   'xp': new xpComponent(0),
-  'gold': new goldComponent(200),
+  'gold': new goldComponent(50),
   'imageUrl': new imageUrlComponent("images/player.png"),
   'strength': new strengthComponent(10),
   'intelligence': new intelligenceComponent(10),


### PR DESCRIPTION
## Summary
- Set player's starting gold to 50 to match initial UI.
- Emit `update` event on load so gold, XP, and health stats display correct values immediately.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be49dc0c84832fa8c9ff8eafcd2867