### PR TITLE
Add item usage during fights

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -2,7 +2,7 @@ import { locations, monsterHealthText, monsterNameText, monsterStats } from './l
 import { weapons, } from './item.js';
 import { eventEmitter, } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
-import { player, entityManager, text, goldText, xpText, image } from './script.js';
+import { player, entityManager, text, goldText, xpText, image, healthText } from './script.js';
 import { nameComponent, healthComponent } from './entityComponent.js';
 
 
@@ -116,6 +116,28 @@ function getPlayerAttackValue(level) {
 */
 eventEmitter.on('dodge', () => {
   text.innerText = `You dodge the attack from the ${fighting.name}.`;
+});
+
+/**
+ * Handles using an item during a fight.
+ * Currently supports using health potions to restore player health.
+ */
+eventEmitter.on('useItem', () => {
+  let inventory = player.getComponent('inventory').items;
+  let healthComp = player.getComponent('health');
+  let potionIndex = inventory.indexOf('health potion');
+
+  if (potionIndex !== -1) {
+    inventory.splice(potionIndex, 1);
+    const healAmount = 30;
+    const healed = Math.min(healAmount, healthComp.maxHealth - healthComp.currentHealth);
+    healthComp.currentHealth += healed;
+    healthText.innerText = healthComp.currentHealth;
+    text.innerText = `You use a health potion and recover ${healed} health.`;
+    eventEmitter.emit('healthUpdated');
+  } else {
+    text.innerText = "You don't have any health potions.";
+  }
 });
 
 /**

--- a/location.js
+++ b/location.js
@@ -43,6 +43,9 @@ function attack() {
 function dodge() {
   eventEmitter.emit('dodge');
 }
+function useItem() {
+  eventEmitter.emit('useItem');
+}
 function restart() {
   eventEmitter.emit('restart', player);
 }
@@ -74,8 +77,8 @@ export const locations = [
     },
     {
       name: "fight",
-      "button text": ["Attack", "Item(coming soon)", "Run"],
-      "button functions": [attack, dodge, goTown],
+      "button text": ["Attack", "Use Item", "Run"],
+      "button functions": [attack, useItem, goTown],
       text: "You are fighting a monster.",
       image: true
     },


### PR DESCRIPTION
## Summary
- Add `useItem` handler in fight module to consume health potions and heal the player
- Hook fight UI's second button to new `useItem` action

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be4c0169b0832f8655acc2cdbaa678