### PR TITLE
Add XP-based level progression and stat scaling

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -40,7 +40,7 @@ eventEmitter.on('goFight', () => {
 eventEmitter.on('attack', () => {
   let enemyLevel = enemy.getComponent("level");
   let monsterDamage = getMonsterAttackValue(enemyLevel);
-  let playerDamage = getPlayerAttackValue(enemyLevel);
+  let playerDamage = getPlayerAttackValue();
   let currentWeaponComp = player.getComponent('currentWeapon');
   let weaponIndex = currentWeaponComp.weaponIndex;
   let weaponName = weapons[weaponIndex].name;
@@ -103,10 +103,12 @@ function getMonsterAttackValue(level) {
 }
 
 // gets attack value of the player
-function getPlayerAttackValue(level) {
+function getPlayerAttackValue() {
   let xpComp = player.getComponent("xp");
-  let hit = 1 + (level * 15) + (Math.floor(Math.random() * xpComp.xp));
-  console.log(xpComp.xp);
+  let strengthComp = player.getComponent("strength");
+  let weaponComp = player.getComponent("currentWeapon");
+  let weaponPower = weapons[weaponComp.weaponIndex].power;
+  let hit = strengthComp.strength + weaponPower + Math.floor(Math.random() * xpComp.xp);
   return hit;
 }
   

--- a/script.js
+++ b/script.js
@@ -10,6 +10,12 @@ export const image = document.querySelector("#image");
 export const monsterStats = document.querySelector("#monsterStats");
 export const imageContainer = document.querySelector("#imageContainer");
 
+// XP required for each level. Adjust the formula to tweak progression.
+// Given a current level, returns the XP needed to reach the next level.
+export function getXpForNextLevel(level) {
+  return level * 100;
+}
+
 // Entity
 export class Entity {
   constructor(id) {
@@ -89,6 +95,30 @@ eventEmitter.on('subtractXp', (amount) => {
   xpComp.xp -= amount;
   console.log(`Player lost ${amount} xp. Current xp: ${xpAmt}`);
   eventEmitter.emit("xpUpdated");
+});
+
+// Handle level ups and update displayed XP whenever it changes
+eventEmitter.on('xpUpdated', () => {
+  let xpComp = player.getComponent('xp');
+  let levelComp = player.getComponent('level');
+  xpText.innerText = xpComp.xp;
+
+  // Check if player has enough XP to level up
+  let nextLevelXp = getXpForNextLevel(levelComp.level);
+  if (xpComp.xp >= nextLevelXp) {
+    levelComp.level++;
+
+    // Scale player stats on level up
+    let healthComp = player.getComponent('health');
+    healthComp.maxHealth += 10;
+    healthComp.currentHealth = healthComp.maxHealth;
+    healthText.innerText = healthComp.currentHealth;
+
+    let strengthComp = player.getComponent('strength');
+    strengthComp.strength += 2;
+
+    text.innerText = `You leveled up! You are now level ${levelComp.level}.`;
+  }
 });
 
 // Health handling


### PR DESCRIPTION
## Summary
- add `getXpForNextLevel` to define level XP thresholds
- handle `xpUpdated` to increase level, boost stats, and message player
- factor strength and weapon power into player attack calculations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be4c1a6548832f986520006d9c8bfd