### PR TITLE
Fix button functionality initialization

### DIFF
--- a/location.js
+++ b/location.js
@@ -166,9 +166,6 @@ function createButtons(location) {
   });
 }
   
-  // initialize UI
-  eventEmitter.emit('update', locations[9]);
-  
 /**
  * Updates the UI based on the given location object.
  * 
@@ -199,6 +196,9 @@ eventEmitter.on('update', (location) => {
     monsterStats.style.display = "none";
   }
 });
+
+// initialize UI after registering the update listener
+eventEmitter.emit('update', locations[9]);
 
 /**
  * Updates the UI with the town location data.


### PR DESCRIPTION
## Summary
- Initialize location buttons only after the `update` listener is registered so buttons work on first load

## Testing
- `node --input-type=module -e "import('./location.js').then(m=>console.log('loaded')).catch(e=>console.error(e))"` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be4d19bd5c832fa2ae1ce7459b2716