### PR TITLE
Use event listeners for dynamic buttons

### DIFF
--- a/location.js
+++ b/location.js
@@ -161,7 +161,8 @@ function createButtons(location) {
   location['button text'].forEach((text, index) => {
       const button = document.createElement('button');
       button.innerText = text;
-      button.onclick = location['button functions'][index];
+      button.id = `button${index + 1}`;
+      button.addEventListener('click', location['button functions'][index]);
       buttonContainer.appendChild(button);
   });
 }
@@ -199,8 +200,6 @@ eventEmitter.on('update', (location) => {
 
 // initialize UI after registering the update listener
 eventEmitter.emit('update', locations[9]);
-document.getElementById('button1')
-        ?.addEventListener('click', goPickCharacter);
 
 /**
  * Updates the UI with the town location data.


### PR DESCRIPTION
## Summary
- Attach click handlers using `addEventListener` when creating buttons dynamically.
- Assign predictable button IDs and remove outdated manual event binding.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68becef0f904832fae0d2313ec372fcb