### PR TITLE
Reset player using current template on restart

### DIFF
--- a/endGame.js
+++ b/endGame.js
@@ -1,6 +1,7 @@
 import { locations, } from './location.js';
 import { eventEmitter, } from './eventEmitter.js';
-import { defaultPlayer } from './playerTemplate.js';
+import { currentTemplate } from './playerTemplate.js';
+import { initializePlayer } from './script.js';
 
 eventEmitter.on('winGame', () => {
     eventEmitter.emit('update', (locations[7]));
@@ -18,28 +19,8 @@ eventEmitter.on('lose', () => {
     loseImage.style.display = "block";
   });
 
-eventEmitter.on('restart', (player) => {
-  console.log(player);
-  console.log("Default player object: ", defaultPlayer); // Log default player object
-  // Loop through and reset player components
-  for (let componentName in defaultPlayer) {
-    console.log("Checking for component: ", componentName); // Log each component being checked
-    let playerComponent = player.getComponent(componentName);
-    console.log("Component retrieved: ", playerComponent); // Log component retrieved
-    if (playerComponent) {
-      if (componentName === 'inventory') {
-        console.log('Resetting inventory, default items: ', defaultPlayer[componentName]); // debug inventory component
-        // Reset inventory
-        playerComponent.items = [...defaultPlayer[componentName].items];
-      } else {
-        // For other components, reset their properties
-        let defaultValues = defaultPlayer[componentName];
-        for (let prop in defaultValues) {
-          playerComponent[prop] = defaultValues[prop];
-        }
-      }
-    }
-  }
+eventEmitter.on('restart', () => {
+  initializePlayer(currentTemplate);
   eventEmitter.emit('update', locations[0]);
   console.log("restart function called");
 });


### PR DESCRIPTION
## Summary
- Reset player stats using the currently selected template on restart
- Apply template via `initializePlayer` before emitting town update

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee615ee2c832f9d75166de332c383