### PR TITLE
Start player with weakest weapon and guard weapon purchases

### DIFF
--- a/playerTemplate.js
+++ b/playerTemplate.js
@@ -11,7 +11,7 @@ export const characterTemplates = [
     intelligence: { intelligence: 5 },
     gold: { gold: 100 },
     xp: { xp: 0 },
-    inventory: { items: [weapons[3].name] },
+    inventory: { items: [weapons[0].name] },
   },
   {
     name: 'Mage',
@@ -21,7 +21,7 @@ export const characterTemplates = [
     intelligence: { intelligence: 25 },
     gold: { gold: 75 },
     xp: { xp: 0 },
-    inventory: { items: [weapons[1].name] },
+    inventory: { items: [weapons[0].name] },
   },
   {
     name: 'Rogue',
@@ -31,7 +31,7 @@ export const characterTemplates = [
     intelligence: { intelligence: 10 },
     gold: { gold: 60 },
     xp: { xp: 0 },
-    inventory: { items: [weapons[2].name] },
+    inventory: { items: [weapons[0].name] },
   },
 ];
 

--- a/store.js
+++ b/store.js
@@ -27,14 +27,15 @@ export function buyHealth() {
 export function buyWeapon() {
   let goldComponent = player.getComponent('gold');
   let weaponComp = player.getComponent('currentWeapon');
-  let inventoryComponent = player.getComponent('inventory');
 
-  // Check if player can afford the next weapon
-  if (goldComponent.gold >= 30) {
-      // Upgrade weapon
-      eventEmitter.emit('subtractGold', 30);
-      eventEmitter.emit('weaponUp');
-   } else {
+  // Ensure a stronger weapon is available before purchasing
+  if (weaponComp.weaponIndex >= weapons.length - 1) {
+    text.innerText = "You already have the most powerful weapon!";
+  } else if (goldComponent.gold >= 30) {
+    // Upgrade weapon
+    eventEmitter.emit('subtractGold', 30);
+    eventEmitter.emit('weaponUp');
+  } else {
     text.innerText = "You do not have enough gold to buy a weapon.";
   }
 }


### PR DESCRIPTION
## Summary
- Default all character templates to start with the weakest weapon so upgrades can be bought in-game
- Prevent spending gold on weapon upgrades when the player already has the strongest weapon

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check playerTemplate.js`
- `node --check store.js`


------
https://chatgpt.com/codex/tasks/task_e_68beee25339c832fabe63bddd5b6db02