### PR TITLE
Add character preview element for selection screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
   <div id="imageContainer">
     <img id="image" src="imgs/openScreen.png" alt="image">
   </div>
+  <img id="characterPreview" style="display: none;" alt="character preview">
   <div id="monsterStats">
     <span class="stat">Monster Name: <strong><span id="monsterName"></span></strong></span>
     <span class="stat">Health: <strong><span id="monsterHealth"></span></strong></span>

--- a/location.js
+++ b/location.js
@@ -1,5 +1,5 @@
 import { eventEmitter } from './eventEmitter.js';
-import { player, xpText, healthText, goldText, text, image, imageContainer, monsterStats, selectCharacter } from './script.js';
+import { player, xpText, healthText, goldText, text, image, imageContainer, monsterStats, selectCharacter, characterPreview } from './script.js';
 import { characterTemplates } from './playerTemplate.js';
 import { buyHealth, buyWeapon, sellWeapon } from './store.js';
 import { pickTwo, pickEight } from './easterEgg.js';
@@ -155,14 +155,14 @@ export function generatePickCharacterLocation() {
   const summaries = characterTemplates
     .map(t => `${t.name}: HP ${t.health.currentHealth}, STR ${t.strength.strength}, INT ${t.intelligence.intelligence}`)
     .join('\n');
+  characterPreview.src = buttonImages[0];
   return {
     name: 'pickCharacter',
     'button text': buttonText,
     'button functions': buttonFunctions,
     'button images': buttonImages,
     text: `Choose your character:\n${summaries}`,
-    image: true,
-    imageUrl: buttonImages[0]
+    image: false
   };
 }
 
@@ -181,7 +181,7 @@ function createButtons(location) {
       button.addEventListener('click', location['button functions'][index]);
     if (location['button images'] && location['button images'][index]) {
       const showImage = () => {
-        image.src = location['button images'][index];
+        characterPreview.src = location['button images'][index];
       };
       button.addEventListener('mouseenter', showImage);
       button.addEventListener('focus', showImage);
@@ -207,6 +207,15 @@ eventEmitter.on('update', (location) => {
   xpText.innerText = xpComponent.xp;
   healthText.innerText = healthComponent.currentHealth;
   console.log("update called")
+  if (location.name === 'pickCharacter') {
+    characterPreview.style.display = 'block';
+    if (location['button images'] && location['button images'][0]) {
+      characterPreview.src = location['button images'][0];
+    }
+  } else {
+    characterPreview.style.display = 'none';
+    characterPreview.src = '';
+  }
   if (location.image == false) {
     imageContainer.style.display = "none";
     image.style.display = "none";

--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ export const goldText = document.querySelector("#goldText");
 export const image = document.querySelector("#image");
 export const monsterStats = document.querySelector("#monsterStats");
 export const imageContainer = document.querySelector("#imageContainer");
+export const characterPreview = document.querySelector("#characterPreview");
 
 // XP required for each level. Adjust the formula to tweak progression.
 // Given a current level, returns the XP needed to reach the next level.


### PR DESCRIPTION
## Summary
- add dedicated `#characterPreview` image in the HTML
- show character previews during selection without replacing location art
- hide preview when game proceeds to other screens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check location.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68beff54329c832fb544f9190dfab9d7