### PR TITLE
Preload character images before selection

### DIFF
--- a/location.js
+++ b/location.js
@@ -3,6 +3,11 @@ import { player, xpText, healthText, goldText, text, image, imageContainer, mons
 import { characterTemplates } from './playerTemplate.js';
 import { buyHealth, buyWeapon, sellWeapon } from './store.js';
 import { pickTwo, pickEight } from './easterEgg.js';
+// Preload character images so they're cached before the selection screen is shown
+characterTemplates.forEach(t => {
+  const img = new Image();
+  img.src = t.imageUrl;
+});
 export const monsterNameText = document.querySelector("#monsterName");
 export const monsterHealthText = document.querySelector("#monsterHealth");
 export const monsterText = document.querySelector("#monsterText");


### PR DESCRIPTION
## Summary
- Cache all character images during initialization to ensure they're ready before the selection screen is displayed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf01135264832fbef99eec0300eaba