### PR TITLE
Add handlers to reset preview image after button focus lost

### DIFF
--- a/location.js
+++ b/location.js
@@ -185,12 +185,29 @@ function createButtons(location) {
       button.id = `button${index + 1}`;
       button.addEventListener('click', location['button functions'][index]);
     if (location['button images'] && location['button images'][index]) {
+      const buttonImage = location['button images'][index];
+
       const showImage = () => {
-        characterPreview.src = location['button images'][index];
+        characterPreview.src = buttonImage;
+        characterPreview.alt = text;
+        image.src = buttonImage;
+        image.alt = text;
       };
+
+      const revertImage = () => {
+        const defaultSrc = location.imageUrl || 'imgs/openScreen.png';
+        characterPreview.src = defaultSrc;
+        characterPreview.alt = defaultSrc;
+        image.src = defaultSrc;
+        image.alt = defaultSrc;
+      };
+
       button.addEventListener('mouseenter', showImage);
       button.addEventListener('focus', showImage);
       button.addEventListener('touchstart', showImage);
+      button.addEventListener('mouseleave', revertImage);
+      button.addEventListener('blur', revertImage);
+      button.addEventListener('touchend', revertImage);
     }
       buttonContainer.appendChild(button);
   });


### PR DESCRIPTION
## Summary
- reset character preview when button interaction ends
- default image/alt used when leaving character buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0882e360832f9c9dac9bf89dc882