### PR TITLE
Enhance pixel art rendering for images

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,9 +52,10 @@ body {
 }
 
 #image {
-  width: 100%; /* Makes the image responsive, adjusting to the container's width */
-  max-height: 200px;
-  width: auto;
+  width: 200px; /* Fixed size to preserve pixel art sharpness */
+  height: 200px; /* Fixed size to preserve pixel art sharpness */
+  image-rendering: crisp-edges;
+  image-rendering: pixelated;
   margin: 0 auto; /* Centers the image within its container */
   border: 1px solid black; /* Optional: adds a border around the image */
   padding: 5px; /* Optional: adds some space around the image */


### PR DESCRIPTION
## Summary
- remove conflicting width rules and add fixed 200x200 size for the game image
- enable pixelated image rendering with crisp-edges fallback for sharper pixels

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2a6e8618832fad695b148778aaf2