### PR TITLE
Fix narrow viewport overflow with responsive scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -114,6 +114,12 @@ button:focus-visible {
   outline-offset: 0;
 }
 
+@media (max-width: 400px) {
+  :root {
+    --scale: calc(100vw / 400);
+  }
+}
+
 @media (min-width: 800px) {
   :root {
     --scale: 2;


### PR DESCRIPTION
## Summary
- Scale game canvas down on viewports under 400px wide using a max-width media query

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf562135e0832f94923f6f3af979f9