### PR TITLE
docs: enforce SVG-only images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS Instructions
+
+- Only create or commit images in SVG format.
+- Do not create or commit binary image files (e.g., PNG, JPG, GIF).
+


### PR DESCRIPTION
## Summary
- add AGENTS instructions to only create SVG images and avoid binary formats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7c1f7174832fbff9eaa69e4869bf