### PR TITLE
Add HUD container with SVG icons and responsive styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -47,6 +47,7 @@ body {
 
 #hud {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   border: 1px black solid;
   color: black;
@@ -58,6 +59,7 @@ body {
   align-items: center;
   gap: 4px;
   padding: 2px 4px;
+  flex: 1 1 auto;
 }
 
 .hud-icon {


### PR DESCRIPTION
## Summary
- group player stats into a dedicated HUD bar with color-coded sections
- replace PNG icons with SVG images for health, gold, and XP
- maintain responsive HUD alignment within the 400px game container
- allow HUD sections to wrap to keep all stats visible

## Testing
- `node - <<'NODE'\nimport puppeteer from 'puppeteer';\n...\nNODE` → `ERR_MODULE_NOT_FOUND: Cannot find package 'puppeteer'`
- `npm install --no-save puppeteer@21.0.0` → download failed with code 403


------
https://chatgpt.com/codex/tasks/task_e_68bf7cd318d4832f879c41fa5f150de8