### PR TITLE
Account for border width in game container scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,6 +33,7 @@ body {
   margin: 0 auto;
   border: 4px solid transparent;
   border-image: url('imgs/backgrounds/frame.svg') 4;
+  box-sizing: border-box;
   image-rendering: pixelated;
 }
 


### PR DESCRIPTION
## Summary
- add border-box sizing to game container so its border doesn't exceed the scaled dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c023664e14832fada9ccc9cb76c70a