### PR TITLE
Fix game container border scaling to prevent overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,8 +28,8 @@ body {
 }
 
 #gameContainer {
-  width: calc(400px * var(--scale));
-  height: calc(500px * var(--scale));
+  width: calc(400px * var(--scale) + 8px);
+  height: calc(500px * var(--scale) + 8px);
   margin: 0 auto;
   border: 4px solid transparent;
   border-image: url('imgs/backgrounds/frame.svg') 4;
@@ -156,7 +156,7 @@ button:focus-visible {
 
 @media (max-width: 400px) {
   :root {
-    --scale: calc(100vw / 400);
+    --scale: calc((100vw - 8px) / 400);
   }
 }
 


### PR DESCRIPTION
## Summary
- include border width in game container dimensions
- adjust scale variable for narrow viewports to avoid horizontal scrolling

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c031931ed8832f84137c42f0fe449b