### PR TITLE
Fix: hide game container overflow on narrow viewports

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,7 @@ body {
   border-image: url('imgs/backgrounds/frame.svg') 4;
   box-sizing: border-box;
   image-rendering: pixelated;
+  overflow: hidden;
 }
 
 #game {


### PR DESCRIPTION
## Summary
- hide overflow on game container to prevent horizontal scroll on viewports narrower than 400px

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c03b0254b0832f8a3059e46c540ea4