### PR TITLE
Add viewport meta tag for responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>CveCrwlr</title>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
   <link rel="stylesheet" href="style.css">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Summary
- Add viewport meta tag before styles to ensure proper scaling on different devices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d06a3e8832fad65702d75a324c2