### PR TITLE
Use clamp-based responsive scale

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ button,
 }
 
 :root {
-  --scale: 1;
+  --scale: clamp(0.5, min(calc((100vw - 8px) / 400), calc((100vh - 8px) / 500)), 6);
 }
 
 body {


### PR DESCRIPTION
## Summary
- Replace static `--scale` with viewport-aware `clamp` formula

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d8f8ffc832f9524743e420f5e4f