### PR TITLE
Use clamp-based responsive scale

### DIFF
--- a/style.css
+++ b/style.css
@@ -155,26 +155,3 @@ button:focus-visible {
   outline-offset: 0;
 }
 
-@media (max-width: 400px) {
-  :root {
-    --scale: calc((100vw - 8px) / 400);
-  }
-}
-
-@media (min-width: 800px) {
-  :root {
-    --scale: 2;
-  }
-}
-
-@media (min-width: 1200px) {
-  :root {
-    --scale: 3;
-  }
-}
-
-@media (min-width: 1600px) {
-  :root {
-    --scale: 4;
-  }
-}


### PR DESCRIPTION
## Summary
- Replace static `--scale` with viewport-aware `clamp` formula
- Remove width-based media query overrides for `--scale`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c09ee9c200832f95fb03e9147a2ba7