### PR TITLE
Use clamp-based responsive scale

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ button,
 }
 
 :root {
-  --scale: clamp(0.5, min(calc((100vw - 8px) / 400), calc((100vh - 8px) / 500)), 6);
+  --scale: clamp(0.5, min(calc((100vw - 8px) / 400px), calc((100vh - 8px) / 500px)), 6);
 }
 
 body {


### PR DESCRIPTION
## Summary
- ensure clamp-based `--scale` remains unitless by dividing viewport lengths by pixel values

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/CveCrwlr2/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68c0a13bbda0832fa8833e61f943e69f