### PR TITLE
fix: remove unit from scale denominator

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,11 @@ button,
 }
 
 :root {
-  --scale: clamp(0.5, min(calc((100vw - 8px) / 400px), calc((100vh - 8px) / 500px)), 6);
+  --scale: clamp(
+    0.5,
+    calc(min((100vw - 8px) / 400, (100vh - 8px) / 500) / 1px),
+    6
+  );
 }
 
 body {


### PR DESCRIPTION
## Summary
- ensure responsive scale uses only unitless divisors

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c0a3403f6c832f99dd8feed82d4bd3