### PR TITLE
Scale game UI to larger screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ button,
 }
 
 :root {
-  --scale: 1;
+  --scale: min(calc((100vw - 8px) / 400), calc((100vh - 8px) / 500));
 }
 
 body {
@@ -157,11 +157,5 @@ body {
 button:focus-visible {
   outline: 3px solid limegreen;
   outline-offset: 0;
-}
-
-@media (max-width: 400px) {
-  :root {
-    --scale: calc((100vw - 8px) / 400);
-  }
 }
 


### PR DESCRIPTION
## Summary
- Adjust CSS to scale the game container based on viewport width and height, allowing the game to occupy more space on desktop screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1655d45ec832fb1d65eb4e5adef03