### PR TITLE
Fix weapon sale to match weaponDown and preserve inventory

### DIFF
--- a/store.js
+++ b/store.js
@@ -41,19 +41,19 @@ export function buyWeapon() {
 }
 
 /**
- * Sells the oldest weapon in the inventory, subtracting its gold value, 
- * updating the gold text, removing the sold weapon from the inventory array,
- * updating the text with the sold weapon name, and updating the inventory text.
-*/
+ * Sells the most recently acquired weapon, adds its gold value,
+ * downgrades the current weapon and updates the player text with
+ * the sold weapon name and remaining inventory.
+ */
 export function sellWeapon() {
   let inventoryComponent = player.getComponent('inventory').items;
   if (inventoryComponent.length > 1) {
+    let soldWeapon = inventoryComponent[inventoryComponent.length - 1];
     eventEmitter.emit('addGold', 20);
     eventEmitter.emit('weaponDown');
-    let soldWeapon = inventoryComponent.shift();
-    text.innerText = "You sold a " + soldWeapon + ".";
-    text.innerText += " In your inventory you have: " + inventoryComponent;
+    text.innerText = 'You sold a ' + soldWeapon + '.';
+    text.innerText += ' In your inventory you have: ' + inventoryComponent;
   } else {
     text.innerText = "Don't sell your only weapon!";
-  };
+  }
 }


### PR DESCRIPTION
## Summary
- ensure sellWeapon sells the same weapon removed by weaponDown
- keep at least one weapon in inventory and show correct sale message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1698827a4832faac839223c1cd1cb