### PR TITLE
Clamp health and remove debug logging

### DIFF
--- a/store.js
+++ b/store.js
@@ -8,13 +8,16 @@ import { weapons } from './item.js';
  */
 export function buyHealth() {
   let goldComponent = player.getComponent('gold');
+  let healthComponent = player.getComponent('health');
+  if (healthComponent.currentHealth >= healthComponent.maxHealth) {
+    text.innerText = 'Your health is already full.';
+    return;
+  }
   if (goldComponent.gold >= 10) {
-    console.log(goldComponent.gold);
     eventEmitter.emit('subtractGold', 10);
     eventEmitter.emit('addHealth', 10);
   } else {
-    text.innerText = "You do not have enough gold to buy health.";
-    // Handle insufficient gold
+    text.innerText = 'You do not have enough gold to buy health.';
   }
 }
 


### PR DESCRIPTION
## Summary
- Clamp health increases to max and emit healthUpdated only when health changes
- Emit healthUpdated on damage events
- Remove debug console logs from gameplay scripts for cleaner output
- Prevent gold deduction when buying health at full health

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b0ee8748832f9e2258715159225b