### PR TITLE
Allow random fights across full monster lists

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -67,9 +67,9 @@ eventEmitter.on('attack', () => {
  * Calls goFight() to update the UI for the fight.
 */
 eventEmitter.on('fightSmall', () => {
-  fighting = smallMonsters[Math.floor(Math.random() * 3)];
+  fighting = smallMonsters[Math.floor(Math.random() * smallMonsters.length)];
   eventEmitter.emit('goFight');
-  console.log("Slime button clicked");
+  console.log('Slime button clicked');
 });
 
 /**
@@ -78,7 +78,7 @@ eventEmitter.on('fightSmall', () => {
  * Calls goFight() to update the UI for the fight.
  */
 eventEmitter.on('fightMedium', () => {
-  fighting = mediumMonsters[Math.floor(Math.random() * 3)];
+  fighting = mediumMonsters[Math.floor(Math.random() * mediumMonsters.length)];
   eventEmitter.emit('goFight');
 });
 
@@ -88,9 +88,9 @@ eventEmitter.on('fightMedium', () => {
  * Calls goFight() to update the UI for the fight.
 */
 eventEmitter.on('fightBoss', () => {
-  fighting = bossMonsters[0];
+  fighting = bossMonsters[Math.floor(Math.random() * bossMonsters.length)];
   eventEmitter.emit('goFight');
-})
+});
 
 /**
  * Calculates the attack damage value for a monster based on its level.


### PR DESCRIPTION
## Summary
- Expand random monster selection for small and medium encounters to span all monsters
- Randomize boss fights across the full boss list

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/CveCrwlr2/package.json')*
- `node --input-type=module - <<'NODE'
import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
function sample(monsters, n) {
  const seen = new Set();
  for (let i = 0; i < 1000; i++) {
    const idx = Math.floor(Math.random() * monsters.length);
    seen.add(idx);
  }
  console.log(n, 'monsters length', monsters.length, 'unique indexes', seen.size);
}
sample(smallMonsters, 'small');
sample(mediumMonsters, 'medium');
sample(bossMonsters, 'boss');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c1b2aa21c4832f8f4a296365602977