### PR TITLE
Add functional inventory screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ CveCrwlr is a simple browser-based adventure game. This guide explains how anyon
 2. Use the buttons to explore:
    - **Go to store** – buy health or weapons and sell your current weapon.
    - **Go to cave** – fight small or medium monsters for experience and gold.
-   - **Stats / Inventory** – check your health, gold, experience, and items.
+   - **Stats** – check your health, gold, experience, and equipped weapon.
+   - **Inventory** – view the items you are carrying.
    - **Fight Boss** – challenge the boss when you are ready.
 3. During combat, choose **Attack** to damage the monster, **Item** (coming soon), or **Run** to return to town.
 4. If you defeat a monster, you earn experience and gold. If your health reaches zero, the **REPLAY?** buttons let you start over.
@@ -33,6 +34,6 @@ CveCrwlr is a simple browser-based adventure game. This guide explains how anyon
 ## Testing Tips
 - Try buying and selling items to ensure the store works as expected.
 - Fight different monster types to verify combat and rewards.
-- Use the stats screen to confirm that health, gold, experience, and inventory update correctly.
+- Use the stats and inventory screens to confirm that health, gold, experience, and items update correctly.
 
 Enjoy exploring CveCrwlr!

--- a/location.js
+++ b/location.js
@@ -148,6 +148,13 @@ export const locations = [
       "button functions": [goHomeScreen],
       text: "Changelog:\n- Added Settings and Changelog screens.",
       image: false
+    },
+    {
+      name: 'inventory',
+      'button text': ['Go to town square'],
+      'button functions': [goTown],
+      text: '',
+      image: false
     }
   ];
 
@@ -296,11 +303,16 @@ export function goStats() {
   console.log("Stats function called");
 }
 /**
- * Updates the UI with the store location data.
+ * Updates the UI with the inventory location data.
  */
 export function goInventory() {
-  eventEmitter.emit('update', (locations[5]) );
-  console.log("Inventory function called");
+  let inventoryLoc = locations.find(l => l.name === 'inventory');
+  let items = player.getComponent('inventory').items;
+  inventoryLoc.text = items.length
+    ? 'In your inventory you have: ' + items.join(', ')
+    : 'Your inventory is empty.';
+  eventEmitter.emit('update', inventoryLoc);
+  console.log('Inventory function called');
 }
   
 /**

--- a/location.js
+++ b/location.js
@@ -4,6 +4,7 @@ import { characterTemplates } from './playerTemplate.js';
 import { buyHealth, buyWeapon, sellWeapon } from './store.js';
 import { pickTwo, pickEight } from './easterEgg.js';
 import { getImageUrl } from './imageLoader.js';
+import { weapons } from './item.js';
 // Preload character images so they're cached before the selection screen is shown
 characterTemplates.forEach(t => {
   const img = new Image();
@@ -25,10 +26,9 @@ function gold() {
   //console.log('goldComponent called');
   return goldComponent.gold;
 }
-function inventory() {
-  let inventoryComponent = player.getComponent('inventory');
-  //console.log(inventoryComponent.items);
-  return inventoryComponent.items;
+function equippedWeapon() {
+  let weaponComp = player.getComponent('currentWeapon');
+  return weapons[weaponComp.weaponIndex].name;
 }
 function xp() {
   let xpComponent = player.getComponent('xp');
@@ -100,7 +100,9 @@ export const locations = [
       name: "stats",
       "button text": ["Go to town square", "Go to town square", "Go to town square"],
       "button functions": [goTown, goTown, easterEgg],
-      text: `Health: ${health()} | Gold: ${gold()} | Weapon: ${inventory()} | Experience: ${xp()}`,
+      text:
+        `Health: ${health()} | Gold: ${gold()} | ` +
+        `Weapon: ${equippedWeapon()} | Experience: ${xp()}`,
       image: false
     },
     {
@@ -294,13 +296,14 @@ export function goStats() {
   let healthComp = player.getComponent('health').currentHealth;
   let goldComp = player.getComponent('gold').gold;
   let xpComp = player.getComponent('xp').xp;
-  let inventoryComp = player.getComponent('inventory').items.join(', ');
+  let weaponName = equippedWeapon();
 
-  // Update the text property of the stats location
-  locations[5].text = `Health: ${healthComp} | Gold: ${goldComp} | Weapon: ${inventoryComp} | Experience: ${xpComp}`;
+  locations[5].text =
+    `Health: ${healthComp} | Gold: ${goldComp} | ` +
+    `Weapon: ${weaponName} | Experience: ${xpComp}`;
 
-  eventEmitter.emit('update', (locations[5]) );
-  console.log("Stats function called");
+  eventEmitter.emit('update', locations[5]);
+  console.log('Stats function called');
 }
 /**
  * Updates the UI with the inventory location data.


### PR DESCRIPTION
## Summary
- Add dedicated inventory location and display current items
- Update README instructions and testing tips for separate inventory screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b383db64832fadc5bcb8c5db1940