### PR TITLE
Clear enemy entity after fights

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -22,6 +22,16 @@ let enemy;
 let enemyHealth;
 let enemyName;
 
+function clearEnemy() {
+  if (enemy) {
+    entityManager.removeEntity(enemy.id);
+    enemy = null;
+    enemyHealth = null;
+    enemyName = null;
+    fighting = null;
+  }
+}
+
 eventEmitter.on('goFight', () => {
   eventEmitter.emit('update', (locations[3]));
   enemy = entityManager.createEntity({
@@ -60,10 +70,13 @@ eventEmitter.on('attack', () => {
   }
 });
 
+eventEmitter.on('goTown', clearEnemy);
+eventEmitter.on('winGame', clearEnemy);
+
 
 /**
  * Starts a fight with a random small monster.
- * Sets the fighting variable to a random small monster index. 
+ * Sets the fighting variable to a random small monster index.
  * Calls goFight() to update the UI for the fight.
 */
 eventEmitter.on('fightSmall', () => {
@@ -156,5 +169,6 @@ function defeatMonster() {
   eventEmitter.emit('addXp', fighting.level);
   goldText.innerText = gold.gold;
   xpText.innerText = xp.xp;
+  clearEnemy();
   eventEmitter.emit('update', (locations[4]));
 }

--- a/location.js
+++ b/location.js
@@ -270,8 +270,9 @@ eventEmitter.emit('update', locations[9]);
  * Updates the UI with the town location data.
  */
 export function goTown() {
+  eventEmitter.emit('goTown');
   eventEmitter.emit('update', (locations[0]) );
-  console.log("Town function called");
+  console.log('Town function called');
 }
   
 /**


### PR DESCRIPTION
## Summary
- add `clearEnemy` helper to remove enemies from the entity manager and reset references
- trigger cleanup on run and game win events
- emit `goTown` event when leaving town to ensure run action cleans up enemies

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node test.mjs` *(initial 1, after runs 1, after victories 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e05b6d7c832fa2915a83b65aa7c3