### PR TITLE
Ensure potions only used when health not full

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -143,17 +143,23 @@ eventEmitter.on('useItem', () => {
   let healthComp = player.getComponent('health');
   let potionIndex = inventory.indexOf('health potion');
 
-  if (potionIndex !== -1) {
-    inventory.splice(potionIndex, 1);
-    const healAmount = 30;
-    const healed = Math.min(healAmount, healthComp.maxHealth - healthComp.currentHealth);
-    healthComp.currentHealth += healed;
-    healthText.innerText = healthComp.currentHealth;
-    text.innerText = `You use a health potion and recover ${healed} health.`;
-    eventEmitter.emit('healthUpdated');
-  } else {
+  if (potionIndex === -1) {
     text.innerText = "You don't have any health potions.";
+    return;
   }
+
+  if (healthComp.currentHealth >= healthComp.maxHealth) {
+    text.innerText = 'Your health is already full.';
+    return;
+  }
+
+  inventory.splice(potionIndex, 1);
+  const healAmount = 30;
+  const healed = Math.min(healAmount, healthComp.maxHealth - healthComp.currentHealth);
+  healthComp.currentHealth += healed;
+  healthText.innerText = healthComp.currentHealth;
+  text.innerText = `You use a health potion and recover ${healed} health.`;
+  eventEmitter.emit('healthUpdated');
 });
 
 /**


### PR DESCRIPTION
## Summary
- add early return when no potion found
- prevent potion usage at max health and show message

## Testing
- `npm test` (fails: Could not read package.json)
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c1e29e1f34832f8e1a52a0491a0d26