### PR TITLE
Guard debug logging in gameplay modules

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -1,5 +1,17 @@
-export const debug = false;
+let debug = false;
 
+/**
+ * Enables or disables debug logging.
+ * @param {boolean} value If true, log output is enabled.
+ */
+export function setDebug(value) {
+  debug = value;
+}
+
+/**
+ * Logs to the console when debug mode is active.
+ * @param {...any} args Values to log.
+ */
 export function debugLog(...args) {
   if (debug) {
     console.log(...args);


### PR DESCRIPTION
## Summary
- allow debug logging to be toggled at runtime via `setDebug`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e7ce15e8832f8054fe41e68daa64