### PR TITLE
Clone character templates on selection

### DIFF
--- a/playerTemplate.js
+++ b/playerTemplate.js
@@ -41,3 +41,7 @@ export let currentTemplate = characterTemplates[0];
 // Provide a default export for compatibility with existing code expecting a default player.
 export const defaultPlayer = characterTemplates[0];
 
+export function setCurrentTemplate(template) {
+  currentTemplate = template;
+}
+

--- a/script.js
+++ b/script.js
@@ -1,7 +1,11 @@
 import { eventEmitter } from './eventEmitter.js';
 import { nameComponent, healthComponent, levelComponent, imageUrlComponent, xpComponent, goldComponent, strengthComponent, intelligenceComponent, currentWeaponComponent, inventoryComponent } from './entityComponent.js';
 import { weapons } from './item.js';
-import { characterTemplates, currentTemplate } from './playerTemplate.js';
+import {
+  characterTemplates,
+  currentTemplate,
+  setCurrentTemplate,
+} from './playerTemplate.js';
 import { preloadImages, getImageUrl } from './imageLoader.js';
 
 export const text = document.querySelector("#text");
@@ -139,7 +143,10 @@ export function initializePlayer(template) {
  * @param {number} index - Index of the character template to select.
  */
 export function selectCharacter(index) {
-  Object.assign(currentTemplate, characterTemplates[index]);
+  const template = typeof structuredClone === 'function'
+    ? structuredClone(characterTemplates[index])
+    : JSON.parse(JSON.stringify(characterTemplates[index]));
+  setCurrentTemplate(template);
   initializePlayer(currentTemplate);
   import('./location.js').then(module => {
     eventEmitter.emit('update', module.locations[0]);


### PR DESCRIPTION
## Summary
- Deep clone character templates when a player is selected
- Expose a setter to update the global currentTemplate reference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f66826ac832fac4bb7e20fbce4a2