### PR TITLE
Centralize health UI updates via event listener

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -2,7 +2,7 @@ import { locations, monsterHealthText, monsterNameText, monsterStats } from './l
 import { weapons, } from './item.js';
 import { eventEmitter, } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
-import { player, entityManager, text, goldText, xpText, image, healthText } from './script.js';
+import { player, entityManager, text, goldText, xpText, image } from './script.js';
 import { nameComponent, healthComponent } from './entityComponent.js';
 import { getImageUrl } from './imageLoader.js';
 
@@ -157,7 +157,6 @@ eventEmitter.on('useItem', () => {
   const healAmount = 30;
   const healed = Math.min(healAmount, healthComp.maxHealth - healthComp.currentHealth);
   healthComp.currentHealth += healed;
-  healthText.innerText = healthComp.currentHealth;
   text.innerText = `You use a health potion and recover ${healed} health.`;
   eventEmitter.emit('healthUpdated');
 });

--- a/script.js
+++ b/script.js
@@ -181,7 +181,7 @@ eventEmitter.on('xpUpdated', () => {
     let healthComp = player.getComponent('health');
     healthComp.maxHealth += 10;
     healthComp.currentHealth = healthComp.maxHealth;
-    healthText.innerText = healthComp.currentHealth;
+    eventEmitter.emit('healthUpdated');
 
     let strengthComp = player.getComponent('strength');
     strengthComp.strength += 2;
@@ -192,12 +192,15 @@ eventEmitter.on('xpUpdated', () => {
 });
 
 // Health handling
+eventEmitter.on('healthUpdated', () => {
+  const healthComp = player.getComponent('health');
+  healthText.innerText = healthComp.currentHealth;
+});
 eventEmitter.on('addHealth', (amount) => {
   let healthComp = player.getComponent('health');
   let newHealth = Math.min(healthComp.currentHealth + amount, healthComp.maxHealth);
   if (newHealth !== healthComp.currentHealth) {
     healthComp.currentHealth = newHealth;
-    healthText.innerText = healthComp.currentHealth;
     eventEmitter.emit('healthUpdated');
   }
 });
@@ -209,7 +212,6 @@ eventEmitter.on('playerDamaged', (damageAmount) => {
   );
   if (newHealth !== healthComp.currentHealth) {
     healthComp.currentHealth = newHealth;
-    healthText.innerText = healthComp.currentHealth;
     eventEmitter.emit('healthUpdated');
   }
 


### PR DESCRIPTION
## Summary
- Add `healthUpdated` listener to update health text from a single spot
- Emit `healthUpdated` on level-ups, healing, and damage instead of updating UI directly
- Drop unused health text references in fight scenes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f90cb164832fb1f6bc02929d28a0