### PR TITLE
Clear enemy entity on loss

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -72,6 +72,7 @@ eventEmitter.on('attack', () => {
 
 eventEmitter.on('goTown', clearEnemy);
 eventEmitter.on('winGame', clearEnemy);
+eventEmitter.on('lose', clearEnemy);
 
 
 /**

--- a/fight.js
+++ b/fight.js
@@ -56,6 +56,10 @@ eventEmitter.on('attack', () => {
   let weaponIndex = currentWeaponComp.weaponIndex;
   let weaponName = weapons[weaponIndex].name;
   eventEmitter.emit('playerDamaged', monsterDamage);
+  // Guard against enemy being cleared if the player dies during this attack
+  if (!enemy || !enemyHealth || !enemyName) {
+    return;
+  }
   enemyHealth.currentHealth = Math.max(0, enemyHealth.currentHealth - playerDamage);
   monsterHealthText.innerText = enemyHealth.currentHealth;
   text.innerText = 'The ' + enemyName.name + ' attacks for ' + monsterDamage + '.';


### PR DESCRIPTION
## Summary
- clear enemy entity when player loses to avoid leftover entries

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --input-type=module <test>`

------
https://chatgpt.com/codex/tasks/task_e_68c1fc34a868832f9c48fae714b83380