### PR TITLE
Guard attack handler after player loss

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -56,6 +56,10 @@ eventEmitter.on('attack', () => {
   let weaponIndex = currentWeaponComp.weaponIndex;
   let weaponName = weapons[weaponIndex].name;
   eventEmitter.emit('playerDamaged', monsterDamage);
+  // Guard against enemy being cleared if the player dies during this attack
+  if (!enemy || !enemyHealth || !enemyName) {
+    return;
+  }
   enemyHealth.currentHealth = Math.max(0, enemyHealth.currentHealth - playerDamage);
   monsterHealthText.innerText = enemyHealth.currentHealth;
   text.innerText = 'The ' + enemyName.name + ' attacks for ' + monsterDamage + '.';


### PR DESCRIPTION
## Summary
- guard against enemy being cleared mid-attack when the player loses, preventing crash

## Testing
- `npm test` *(fails: package.json missing)*
- `node --input-type=module ./test` *(fails: Cannot find module './test')*


------
https://chatgpt.com/codex/tasks/task_e_68c1fe008af4832f9918238c6b32de7b