### PR TITLE
chore: remove unused subtractXp listener

### DIFF
--- a/script.js
+++ b/script.js
@@ -160,11 +160,6 @@ eventEmitter.on('addXp',(amount) => {
   xpComp.xp += amount;
   eventEmitter.emit('xpUpdated');
 });
-eventEmitter.on('subtractXp', (amount) => {
-  let xpComp = player.getComponent('xp');
-  xpComp.xp -= amount;
-  eventEmitter.emit('xpUpdated');
-});
 
 // Handle level ups and update displayed XP whenever it changes
 eventEmitter.on('xpUpdated', () => {


### PR DESCRIPTION
## Summary
- remove subtractXp listener since nothing emits it

## Testing
- `npm test` *(fails: missing package.json)*
- `npm run lint` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ff72e150832f9cf1cd13df64c9b5