### PR TITLE
Display XP progress toward next level

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -2,7 +2,7 @@ import { locations, monsterHealthText, monsterNameText, monsterStats } from './l
 import { weapons, } from './item.js';
 import { eventEmitter, } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
-import { player, entityManager, text, goldText, xpText, image } from './script.js';
+import { player, entityManager, text, goldText, image } from './script.js';
 import { nameComponent, healthComponent, levelComponent, imageUrlComponent } from './entityComponent.js';
 import { getImageUrl } from './imageLoader.js';
 
@@ -175,12 +175,10 @@ eventEmitter.on('useItem', () => {
 */
 function defeatMonster() {
   let goldReward = (Math.floor(fighting.level * 6.7));
-  let gold = player.getComponent("gold");
-  let xp = player.getComponent("xp");
+  let gold = player.getComponent('gold');
   eventEmitter.emit('addGold', goldReward);
   eventEmitter.emit('addXp', fighting.level);
   goldText.innerText = gold.gold;
-  xpText.innerText = xp.xp;
   clearEnemy();
   eventEmitter.emit('update', (locations[4]));
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,10 @@
     </div>
     <div class="hud-section hud-xp">
       <img src="imgs/xp.svg" class="hud-icon" alt="xp icon">
-      <span>XP: <strong><span id="xpText">0</span></strong></span>
+      <span>XP: <strong><span id="xpText">0/100</span></strong></span>
+      <div id="xpBar" class="xp-bar">
+        <div id="xpBarFill" class="xp-bar-fill"></div>
+      </div>
     </div>
     <div class="hud-section">
       <span>Level: <strong><span id="levelText">0</span></strong></span>

--- a/location.js
+++ b/location.js
@@ -1,5 +1,18 @@
 import { eventEmitter } from './eventEmitter.js';
-import { player, xpText, healthText, goldText, text, image, imageContainer, monsterStats, selectCharacter, characterPreview } from './script.js';
+import {
+  player,
+  xpText,
+  healthText,
+  goldText,
+  text,
+  image,
+  imageContainer,
+  monsterStats,
+  selectCharacter,
+  characterPreview,
+  getXpForNextLevel,
+  xpBarFill
+} from './script.js';
 import { characterTemplates } from './playerTemplate.js';
 import { buyHealth, buyWeapon, sellWeapon } from './store.js';
 import { pickTwo, pickEight } from './easterEgg.js';
@@ -232,9 +245,13 @@ eventEmitter.on('update', (location) => {
   let xpComponent = player.getComponent('xp');
   let healthComponent = player.getComponent('health');
   let goldComponent = player.getComponent('gold');
+  let levelComponent = player.getComponent('level');
+  let requiredXp = getXpForNextLevel(levelComponent.level);
   text.innerText = location.text;
   goldText.innerText = goldComponent.gold;
-  xpText.innerText = xpComponent.xp;
+  xpText.innerText = `${xpComponent.xp}/${requiredXp}`;
+  let progress = (xpComponent.xp / requiredXp) * 100;
+  xpBarFill.style.width = `${progress}%`;
   healthText.innerText = healthComponent.currentHealth;
   debugLog('update called');
   if (location.name === 'pickCharacter') {

--- a/script.js
+++ b/script.js
@@ -9,7 +9,7 @@ import {
 import { preloadImages, getImageUrl } from './imageLoader.js';
 
 export const text = document.querySelector("#text");
-export const xpText = document.querySelector("#xpText");
+export const xpText = document.querySelector('#xpText');
 export const healthText = document.querySelector("#healthText");
 export const goldText = document.querySelector("#goldText");
 export const image = document.querySelector("#image");
@@ -17,6 +17,7 @@ export const levelText = document.querySelector('#levelText');
 export const monsterStats = document.querySelector("#monsterStats");
 export const imageContainer = document.querySelector("#imageContainer");
 export const characterPreview = document.querySelector("#characterPreview");
+export const xpBarFill = document.querySelector('#xpBarFill');
 
 /**
  * Update the global scale based on the window size.
@@ -132,10 +133,10 @@ export function initializePlayer(template) {
     goldComp.gold = template.gold.gold;
     goldText.innerText = goldComp.gold;
   }
+
+  const xpComp = player.getComponent('xp');
   if (template.xp) {
-    const xpComp = player.getComponent('xp');
     xpComp.xp = template.xp.xp;
-    xpText.innerText = xpComp.xp;
   }
   if (template.inventory) {
     const inventoryComp = player.getComponent('inventory');
@@ -149,6 +150,11 @@ export function initializePlayer(template) {
     levelComp.level = template.level.level;
   }
   levelText.innerText = levelComp.level;
+
+  const requiredXp = getXpForNextLevel(levelComp.level);
+  xpText.innerText = `${xpComp.xp}/${requiredXp}`;
+  const progress = (xpComp.xp / requiredXp) * 100;
+  xpBarFill.style.width = `${progress}%`;
 }
 
 /**
@@ -199,7 +205,9 @@ eventEmitter.on('xpUpdated', () => {
     text.innerText = `You leveled up! You are now level ${levelComp.level}.`;
     requiredXp = getXpForNextLevel(levelComp.level);
   }
-  xpText.innerText = xpComp.xp;
+  xpText.innerText = `${xpComp.xp}/${requiredXp}`;
+  const progress = (xpComp.xp / requiredXp) * 100;
+  xpBarFill.style.width = `${progress}%`;
 });
 
 // Health handling

--- a/style.css
+++ b/style.css
@@ -96,6 +96,20 @@ body {
   color: white;
 }
 
+.xp-bar {
+  width: 100%;
+  height: 8px;
+  background-color: black;
+  border: 1px solid white;
+  margin-top: 2px;
+}
+
+.xp-bar-fill {
+  height: 100%;
+  background-color: limegreen;
+  width: 0%;
+}
+
 #monsterStats {
   display: none;
   border: 1px white solid;


### PR DESCRIPTION
## Summary
- Show XP as current and required for next level
- Add XP progress bar and styling
- Sync HUD updates across locations and battles

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b797b880832fbc7507c20ccfc715