### PR TITLE
Integrate armor defense into player damage calculations

### DIFF
--- a/script.js
+++ b/script.js
@@ -250,9 +250,12 @@ eventEmitter.on('addHealth', (amount) => {
 });
 eventEmitter.on('playerDamaged', (damageAmount) => {
   let healthComp = player.getComponent('health');
+  let armorComp = player.getComponent('currentArmor');
+  let defense = armorComp.armorIndex >= 0 ? armor[armorComp.armorIndex].defense : 0;
+  let adjustedDamage = Math.max(0, damageAmount - defense);
   let newHealth = Math.max(
     0,
-    Math.min(healthComp.currentHealth - damageAmount, healthComp.maxHealth)
+    Math.min(healthComp.currentHealth - adjustedDamage, healthComp.maxHealth)
   );
   if (newHealth !== healthComp.currentHealth) {
     healthComp.currentHealth = newHealth;

--- a/tests/armorDefense.test.js
+++ b/tests/armorDefense.test.js
@@ -1,0 +1,38 @@
+let eventEmitter;
+let player;
+let armor;
+
+beforeAll(async () => {
+  document.body.innerHTML = `
+    <div id='text'></div>
+    <div id='xpText'></div>
+    <div id='healthText'></div>
+    <div id='goldText'></div>
+    <div id='image'></div>
+    <div id='levelText'></div>
+    <div id='monsterStats'></div>
+    <div id='imageContainer'></div>
+    <div id='characterPreview'></div>
+    <div id='xpBarFill'></div>
+  `;
+  ({ eventEmitter } = await import('../eventEmitter.js'));
+  ({ player } = await import('../script.js'));
+  ({ armor } = await import('../item.js'));
+});
+
+beforeEach(() => {
+  const healthComp = player.getComponent('health');
+  healthComp.currentHealth = 100;
+  const armorComp = player.getComponent('currentArmor');
+  armorComp.armorIndex = 1;
+});
+
+test('playerDamaged subtracts armor defense from damage', () => {
+  const healthComp = player.getComponent('health');
+  const armorComp = player.getComponent('currentArmor');
+  const damage = 20;
+  const defense = armor[armorComp.armorIndex].defense;
+  const expectedHealth = healthComp.currentHealth - Math.max(0, damage - defense);
+  eventEmitter.emit('playerDamaged', damage);
+  expect(healthComp.currentHealth).toBe(expectedHealth);
+});


### PR DESCRIPTION
## Summary
- Reduce incoming damage by equipped armor's defense
- Test that armor mitigates damage during combat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c30af46618832fa22877c6d46ff94e