### PR TITLE
Fix stats screen button to return to town

### DIFF
--- a/location.js
+++ b/location.js
@@ -131,7 +131,7 @@ export const locations = [
     {
       name: "stats",
       "button text": ["Go to town square", "Go to town square", "Go to town square"],
-      "button functions": [goTown, goTown, easterEgg],
+      "button functions": [goTown, goTown, goTown],
       text:
         `Health: ${health()} | Gold: ${gold()} | ` +
         `Weapon: ${equippedWeapon()} | Experience: ${xp()}`,


### PR DESCRIPTION
## Summary
- Ensure Stats screen's third button returns to town by replacing `easterEgg` with `goTown`

## Testing
- `npm test`
- `node -e "const fs=require('fs'); const code=fs.readFileSync('location.js','utf8'); const match=/name: \"stats\"[\s\S]*?\"button functions\": \[(.*?)\]/.exec(code); console.log(match[1]);"`


------
https://chatgpt.com/codex/tasks/task_e_68c34038a074832f89c46e6f55b9be4b