### PR TITLE
fix: update player default image path

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,7 +107,7 @@ export let player = entityManager.createEntity({
   'level': new levelComponent(1),
   'xp': new xpComponent(0),
   'gold': new goldComponent(50),
-  'imageUrl': new imageUrlComponent("images/player.png"),
+  'imageUrl': new imageUrlComponent('imgs/warrior.png'),
   'strength': new strengthComponent(10),
   'defense': new defenseComponent(0),
   'intelligence': new intelligenceComponent(10),


### PR DESCRIPTION
## Summary
- fix player entity's image URL to point to `imgs/warrior.png` so the character sprite loads correctly

## Testing
- `npm test`
- `python launch_game.py` (verify HTTP 200 for `/imgs/warrior.png`)


------
https://chatgpt.com/codex/tasks/task_e_68c341f81e88832fb437eef66abce47e