### PR TITLE
chore: remove trailing commas from imports

### DIFF
--- a/endGame.js
+++ b/endGame.js
@@ -1,5 +1,5 @@
-import { locations, } from './location.js';
-import { eventEmitter, } from './eventEmitter.js';
+import { locations } from './location.js';
+import { eventEmitter } from './eventEmitter.js';
 import { currentTemplate } from './playerTemplate.js';
 import { initializePlayer } from './script.js';
 import { debugLog } from './debug.js';

--- a/fight.js
+++ b/fight.js
@@ -1,6 +1,6 @@
 import { locations, monsterHealthText, monsterNameText, monsterStats } from './location.js';
-import { weapons, } from './item.js';
-import { eventEmitter, } from './eventEmitter.js';
+import { weapons } from './item.js';
+import { eventEmitter } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
 import { player, entityManager, text, goldText, image } from './script.js';
 import {


### PR DESCRIPTION
## Summary
- remove trailing commas from weapons and eventEmitter imports in fight.js
- clean up locations and eventEmitter imports in endGame.js

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3489e844c832fbb514f45deedb50d