### PR TITLE
Add purchasable health potions

### DIFF
--- a/USERMANUAL.md
+++ b/USERMANUAL.md
@@ -26,6 +26,7 @@ The town square is the central hub. From here you can:
 ## Store
 The store offers goods and services:
 - **Buy 10 health (10 gold)**: restores health up to your maximum.
+- **Buy health potion (15 gold)**: adds a potion to your inventory for later use.
 - **Buy weapon (30 gold)**: upgrades to the next weapon tier.
 - **Buy armor (40 gold)**: equips stronger armor for extra defense.
 - **Buy accessories**: each accessory gives permanent bonuses such as extra health or

--- a/location.js
+++ b/location.js
@@ -14,7 +14,14 @@ import {
   xpBarFill
 } from './script.js';
 import { characterTemplates } from './playerTemplate.js';
-import { buyHealth, buyWeapon, buyArmor, buyAccessory, sellWeapon } from './store.js';
+import {
+  buyHealth,
+  buyHealthPotion,
+  buyWeapon,
+  buyArmor,
+  buyAccessory,
+  sellWeapon
+} from './store.js';
 import { pickTwo, pickEight } from './easterEgg.js';
 import { getImageUrl } from './imageLoader.js';
 import { weapons, accessories } from './item.js';
@@ -88,6 +95,7 @@ export const locations = [
       name: "store",
       "button text": [
         'Buy 10 health (10 gold)',
+        'Buy health potion (15 gold)',
         'Buy weapon (30 gold)',
         'Buy armor (40 gold)',
         ...accessoryButtonText,
@@ -96,6 +104,7 @@ export const locations = [
       ],
       "button functions": [
         buyHealth,
+        buyHealthPotion,
         buyWeapon,
         buyArmor,
         ...accessoryButtonFunctions,

--- a/store.js
+++ b/store.js
@@ -22,9 +22,26 @@ export function buyHealth() {
 }
 
 /**
+ * Buys a health potion for later use.
+ * Subtracts gold and adds a potion to the player's consumables.
+ */
+export function buyHealthPotion() {
+  let goldComponent = player.getComponent('gold');
+  let inventory = player.getComponent('inventory').items.consumables;
+  const cost = 15;
+  if (goldComponent.gold >= cost) {
+    eventEmitter.emit('subtractGold', cost);
+    inventory.push('health potion');
+    text.innerText = 'You bought a health potion.';
+  } else {
+    text.innerText = 'You do not have enough gold to buy a health potion.';
+  }
+}
+
+/**
  * Buys a new weapon by subtracting gold, upgrading the weapon,
  * updating the gold text, setting the new weapon name, adding to inventory,
- * updating the text and logging. Checks if the current weapon is already 
+ * updating the text and logging. Checks if the current weapon is already
  * the most powerful and updates text and button if so.
 */
 export function buyWeapon() {

--- a/tests/healthPotion.test.js
+++ b/tests/healthPotion.test.js
@@ -1,0 +1,54 @@
+let buyHealthPotion;
+let player;
+let eventEmitter;
+
+beforeAll(async () => {
+  document.body.innerHTML = `
+    <div id='text'></div>
+    <div id='xpText'></div>
+    <div id='healthText'></div>
+    <div id='goldText'></div>
+    <div id='image'></div>
+    <div id='levelText'></div>
+    <div id='monsterStats'></div>
+    <div id='imageContainer'></div>
+    <div id='characterPreview'></div>
+    <div id='xpBarFill'></div>
+    <div id='controls'></div>
+    <div id='monsterName'></div>
+    <div id='monsterHealth'></div>
+    <div id='monsterText'></div>
+    <div id='monsterHealthStat'></div>
+  `;
+  ({ buyHealthPotion } = await import('../store.js'));
+  ({ eventEmitter } = await import('../eventEmitter.js'));
+  ({ player } = await import('../script.js'));
+  await import('../fight.js');
+});
+
+beforeEach(() => {
+  const goldComp = player.getComponent('gold');
+  goldComp.gold = 100;
+  const healthComp = player.getComponent('health');
+  healthComp.maxHealth = 100;
+  healthComp.currentHealth = 100;
+  player.getComponent('inventory').items.consumables = [];
+});
+
+test('buyHealthPotion adds potion to inventory and subtracts gold', () => {
+  buyHealthPotion();
+  const goldComp = player.getComponent('gold');
+  const inventory = player.getComponent('inventory').items.consumables;
+  expect(goldComp.gold).toBe(85);
+  expect(inventory[0]).toBe('health potion');
+});
+
+test('useItem consumes potion and restores health', () => {
+  const inventory = player.getComponent('inventory').items.consumables;
+  inventory.push('health potion');
+  const healthComp = player.getComponent('health');
+  healthComp.currentHealth = 50;
+  eventEmitter.emit('useItem');
+  expect(healthComp.currentHealth).toBe(80);
+  expect(inventory.length).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Allow buying health potions for 15 gold at the store
- Document health potion availability and usage
- Test purchasing and consuming health potions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c34dcd9974832fac60b2aeb65e5dd7