### PR TITLE
Handle missing enemies in combat listeners

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -58,6 +58,10 @@ eventEmitter.on('goFight', () => {
   image.style.display = 'block';
 });
 eventEmitter.on('attack', () => {
+  if (!enemy) {
+    text.innerText = 'There is no enemy to attack.';
+    return;
+  }
   let enemyLevel = enemy.getComponent('level').level;
   let monsterDamage = getMonsterAttackValue(enemyLevel);
   let playerDamage = getPlayerAttackValue();
@@ -148,6 +152,10 @@ function getPlayerAttackValue() {
  * Updates the text to indicate the player dodged the attack.
 */
 eventEmitter.on('dodge', () => {
+  if (!fighting) {
+    text.innerText = 'You dodge nothing.';
+    return;
+  }
   text.innerText = `You dodge the attack from the ${fighting.name}.`;
 });
 


### PR DESCRIPTION
## Summary
- Avoid attacking when no enemy is present
- Guard dodge listener when no enemy is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c351f66280832f8bed906beda1a02d