### PR TITLE
Validate armor index in damage handler

### DIFF
--- a/USERMANUAL.md
+++ b/USERMANUAL.md
@@ -49,6 +49,7 @@ During combat:
 ## Inventory and Equipment
 The inventory screen lists all items you own. Items are grouped by type:
 - **Weapons** and **Armor**: increase your attack or defense when equipped.
+- If no armor is equipped, you receive no bonus defense.
 - **Accessories**: provide passive bonuses and stack with other gear.
 - **Consumables**: one-use items such as health potions.
 

--- a/script.js
+++ b/script.js
@@ -263,7 +263,12 @@ eventEmitter.on('playerDamaged', (damageAmount) => {
   let armorComp = player.getComponent('currentArmor');
   let defenseComp = player.getComponent('defense');
   let baseDefense = defenseComp ? defenseComp.defense : 0;
-  let armorDefense = armorComp.armorIndex >= 0 ? armor[armorComp.armorIndex].defense : 0;
+  let armorDefense = 0;
+  if (armorComp.armorIndex >= 0 && armorComp.armorIndex < armor.length) {
+    armorDefense = armor[armorComp.armorIndex].defense;
+  } else {
+    armorComp.armorIndex = -1;
+  }
   let totalDefense = baseDefense + armorDefense;
   let adjustedDamage = Math.max(0, damageAmount - totalDefense);
   let newHealth = Math.max(

--- a/tests/armorDefense.test.js
+++ b/tests/armorDefense.test.js
@@ -39,3 +39,14 @@ test('playerDamaged subtracts armor defense from damage', () => {
   eventEmitter.emit('playerDamaged', damage);
   expect(healthComp.currentHealth).toBe(expectedHealth);
 });
+
+test('playerDamaged resets invalid armor index to default defense', () => {
+  const healthComp = player.getComponent('health');
+  const armorComp = player.getComponent('currentArmor');
+  armorComp.armorIndex = armor.length;
+  const damage = 20;
+  const expectedHealth = healthComp.currentHealth - damage;
+  eventEmitter.emit('playerDamaged', damage);
+  expect(healthComp.currentHealth).toBe(expectedHealth);
+  expect(armorComp.armorIndex).toBe(-1);
+});


### PR DESCRIPTION
## Summary
- ensure armor defense only applies when armorIndex is within valid range
- reset invalid armorIndex to prevent erroneous defense
- document lack of defense when no armor is equipped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4136a0b68832faaebd3c6a1a4ff4b