### PR TITLE
Use strict equality for location comparisons in update listener

### DIFF
--- a/location.js
+++ b/location.js
@@ -303,15 +303,15 @@ eventEmitter.on('update', (location) => {
     characterPreview.style.display = 'none';
     characterPreview.src = '';
   }
-  if (location.image == false) {
+  if (location.image === false) {
     imageContainer.style.display = "none";
     image.style.display = "none";
-  } else if (location.image == true) {
+  } else if (location.image === true) {
     imageContainer.style.display = "block";
     image.style.display = "block";
     image.src = getImageUrl(location.imageUrl);
   }
-  if (location.name == "fight") {
+  if (location.name === 'fight') {
     monsterStats.style.display = "block";
   } else {
     monsterStats.style.display = "none";


### PR DESCRIPTION
## Summary
- Use strict equality to check `location.image` and `location.name`
- Standardize comparison style in `update` event listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c41897db60832f98e6d5446def0db4