### PR TITLE
Implement resetPlayer and clean dangling comment

### DIFF
--- a/endGame.js
+++ b/endGame.js
@@ -20,13 +20,15 @@ eventEmitter.on('lose', () => {
     loseImage.style.display = "block";
   });
 
-eventEmitter.on('restart', () => {
+eventEmitter.on('restart', resetPlayer);
+
+/**
+ * Resets the player stats and inventory to starting values,
+ * and updates the UI to the town view.
+ */
+export function resetPlayer() {
   initializePlayer(currentTemplate);
   eventEmitter.emit('update', locations[0]);
   debugLog('restart function called');
-});
+}
 
-  /**
-   * Resets the player stats and inventory to starting values, 
-   * and updates the UI to the town view.
-   */


### PR DESCRIPTION
## Summary
- Replace restart listener inline logic with reusable `resetPlayer`
- Document `resetPlayer` to clarify its role resetting stats and UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c422d8b328832f8d7430f457e0ca0c