### PR TITLE
Handle image preload errors

### DIFF
--- a/imageLoader.js
+++ b/imageLoader.js
@@ -2,11 +2,19 @@ const imageCache = {};
 
 // Preload images from locations, monsters, and player templates
 export async function preloadImages() {
-  const [locModule, monsterModule, templateModule] = await Promise.all([
-    import('./location.js'),
-    import('./monster.js'),
-    import('./playerTemplate.js')
-  ]);
+  let locModule;
+  let monsterModule;
+  let templateModule;
+  try {
+    [locModule, monsterModule, templateModule] = await Promise.all([
+      import('./location.js'),
+      import('./monster.js'),
+      import('./playerTemplate.js')
+    ]);
+  } catch (err) {
+    console.error('Error preloading image modules:', err);
+    return;
+  }
 
   const urls = [];
 
@@ -40,6 +48,9 @@ export async function preloadImages() {
   urls.forEach(url => {
     if (!imageCache[url]) {
       const img = new Image();
+      img.onerror = () => {
+        console.error('Failed to load image:', url);
+      };
       img.src = url;
       imageCache[url] = img;
     }


### PR DESCRIPTION
## Summary
- wrap module imports in a try/catch and log failures so broken preloads are surfaced
- report individual image load errors when a sprite cannot be fetched

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c422dcdf30832faf76076628de1127