### PR TITLE
Add SVG icons for items

### DIFF
--- a/imgs/items/boots-of-swiftness.svg
+++ b/imgs/items/boots-of-swiftness.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="40" y="120" width="40" height="60" fill="#654321" />
+  <rect x="120" y="120" width="40" height="60" fill="#654321" />
+</svg>

--- a/imgs/items/chainmail.svg
+++ b/imgs/items/chainmail.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="40" y="40" width="120" height="120" fill="#C0C0C0" />
+  <circle cx="70" cy="70" r="10" fill="#808080" />
+  <circle cx="130" cy="70" r="10" fill="#808080" />
+  <circle cx="70" cy="130" r="10" fill="#808080" />
+  <circle cx="130" cy="130" r="10" fill="#808080" />
+</svg>

--- a/imgs/items/claw-hammer.svg
+++ b/imgs/items/claw-hammer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="90" y="40" width="20" height="120" fill="#8B4513" />
+  <rect x="70" y="40" width="60" height="20" fill="#A9A9A9" />
+  <rect x="110" y="20" width="20" height="20" fill="#A9A9A9" />
+</svg>

--- a/imgs/items/dagger.svg
+++ b/imgs/items/dagger.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <polygon points="100,20 120,120 80,120" fill="#C0C0C0" />
+  <rect x="90" y="120" width="20" height="60" fill="#654321" />
+</svg>

--- a/imgs/items/gloves-of-strength.svg
+++ b/imgs/items/gloves-of-strength.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="50" y="80" width="40" height="80" fill="#8B4513" />
+  <rect x="110" y="80" width="40" height="80" fill="#8B4513" />
+</svg>

--- a/imgs/items/health-potion.svg
+++ b/imgs/items/health-potion.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="80" y="20" width="40" height="40" fill="#A9A9A9" />
+  <rect x="60" y="60" width="80" height="100" fill="#FF0000" />
+</svg>

--- a/imgs/items/leather-armor.svg
+++ b/imgs/items/leather-armor.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <path d="M60 40h80l20 40v80h-120v-80z" fill="#8B4513" />
+</svg>

--- a/imgs/items/necklace-of-fortitude.svg
+++ b/imgs/items/necklace-of-fortitude.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="80" r="60" fill="none" stroke="#FFD700" stroke-width="20" />
+  <rect x="90" y="140" width="20" height="40" fill="#A9A9A9" />
+</svg>

--- a/imgs/items/plate-armor.svg
+++ b/imgs/items/plate-armor.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="50" y="40" width="100" height="120" fill="#C0C0C0" />
+  <rect x="70" y="60" width="60" height="80" fill="#A9A9A9" />
+</svg>

--- a/imgs/items/ring-of-vitality.svg
+++ b/imgs/items/ring-of-vitality.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="60" fill="none" stroke="#FFD700" stroke-width="20" />
+</svg>

--- a/imgs/items/stick.svg
+++ b/imgs/items/stick.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="95" y="20" width="10" height="160" fill="#8B4513" />
+</svg>

--- a/imgs/items/sword.svg
+++ b/imgs/items/sword.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="95" y="20" width="10" height="120" fill="#C0C0C0" />
+  <rect x="80" y="140" width="40" height="10" fill="#C0C0C0" />
+  <rect x="90" y="150" width="20" height="30" fill="#8B4513" />
+</svg>

--- a/imgs/items/tattered-cloth.svg
+++ b/imgs/items/tattered-cloth.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <polygon points="40,40 160,40 150,100 160,160 40,160 50,100" fill="#808080" />
+</svg>

--- a/item.js
+++ b/item.js
@@ -1,38 +1,46 @@
 export const weapons = [
   {
     name: 'stick',
-    power: 5
+    power: 5,
+    icon: 'imgs/items/stick.svg'
   },
   {
     name: 'dagger',
-    power: 30
+    power: 30,
+    icon: 'imgs/items/dagger.svg'
   },
   {
     name: 'claw hammer',
-    power: 50
+    power: 50,
+    icon: 'imgs/items/claw-hammer.svg'
   },
   {
     name: 'sword',
-    power: 100
+    power: 100,
+    icon: 'imgs/items/sword.svg'
   }
 ];
 
 export const armor = [
   {
     name: 'tattered cloth',
-    defense: 5
+    defense: 5,
+    icon: 'imgs/items/tattered-cloth.svg'
   },
   {
     name: 'leather armor',
-    defense: 15
+    defense: 15,
+    icon: 'imgs/items/leather-armor.svg'
   },
   {
     name: 'chainmail',
-    defense: 30
+    defense: 30,
+    icon: 'imgs/items/chainmail.svg'
   },
   {
     name: 'plate armor',
-    defense: 50
+    defense: 50,
+    icon: 'imgs/items/plate-armor.svg'
   }
 ];
 
@@ -40,23 +48,25 @@ export const accessories = [
   {
     name: 'ring of vitality',
     healthBonus: 20,
-    cost: 50
+    cost: 50,
+    icon: 'imgs/items/ring-of-vitality.svg'
   },
   {
     name: 'gloves of strength',
     strengthBonus: 5,
-    cost: 50
+    cost: 50,
+    icon: 'imgs/items/gloves-of-strength.svg'
   },
   {
     name: 'boots of swiftness',
     agilityBonus: 5,
-    cost: 50
+    cost: 50,
+    icon: 'imgs/items/boots-of-swiftness.svg'
   },
   {
     name: 'necklace of fortitude',
     defenseBonus: 5,
-    cost: 50
+    cost: 50,
+    icon: 'imgs/items/necklace-of-fortitude.svg'
   }
 ];
-
-


### PR DESCRIPTION
## Summary
- add 200x200 SVG icons for weapons, armor, accessories, and health potion
- link item definitions to new SVG icon paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c444cf30b0832f819d98fc5b7ce594