### PR TITLE
Use placeholder for missing monster images

### DIFF
--- a/imgs/placeholder-monster.svg
+++ b/imgs/placeholder-monster.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' shape-rendering='crispEdges'>
+  <rect width='200' height='200' fill='#222'/>
+  <rect x='0' y='90' width='200' height='20' fill='#fff'/>
+  <rect x='90' y='0' width='20' height='200' fill='#fff'/>
+</svg>
+

--- a/monster.js
+++ b/monster.js
@@ -1,270 +1,271 @@
 export const smallMonsters = [
   {
-    name: "Slime",
+    name: 'Slime',
     level: 1,
     health: 15,
     power: 5,
-    imageUrl: "imgs/slimeImage.png"
+    imageUrl: 'imgs/slimeImage.png'
   },
   {
-    name: "Phantom",
+    name: 'Phantom',
     level: 1,
     health: 28,
     power: 8,
-    imageUrl: "imgs/phantom.png"
+    imageUrl: 'imgs/phantom.png'
   },
   {
-    name: "Venomous Serpent",
+    name: 'Venomous Serpent',
     level: 1,
     health: 10,
     power: 3,
-    imageUrl: "imgs/venomousSerpent.png"
+    imageUrl: 'imgs/venomousSerpent.png'
   },
   {
-    name: "Prairie Wolf",
+    name: 'Prairie Wolf',
     level: 2,
     health: 12,
-    imageUrl: "imgs/prairieWolf.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Mountain Viper",
+    name: 'Mountain Viper',
     level: 2,
     health: 13,
-    imageUrl: "imgs/mountainViperImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Swamp Toad",
+    name: 'Swamp Toad',
     level: 2,
     health: 11,
-    imageUrl: "imgs/swampToadImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Feral Ghoul",
+    name: 'Feral Ghoul',
     level: 3,
     health: 15,
-    imageUrl: "imgs/feralGhoulImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Dusty Skeleton",
+    name: 'Dusty Skeleton',
     level: 3,
     health: 14,
-    imageUrl: "imgs/dustySkeletonImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Cave Bat",
+    name: 'Cave Bat',
     level: 3,
     health: 9,
-    imageUrl: "imgs/caveBatImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Bog Rat",
+    name: 'Bog Rat',
     level: 4,
     health: 12,
-    imageUrl: "imgs/bogRatImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Forest Imp",
+    name: 'Forest Imp',
     level: 4,
     health: 8,
-    imageUrl: "imgs/forestImpImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Mud Crab",
+    name: 'Mud Crab',
     level: 4,
     health: 10,
-    imageUrl: "imgs/mudCrabImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Dark Elf",
+    name: 'Dark Elf',
     level: 5,
     health: 28,
-    imageUrl: "imgs/darkElfImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Goblin",
+    name: 'Goblin',
     level: 5,
     health: 20,
-    imageUrl: "imgs/goblinImage.png"    
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Orc Warrior",
+    name: 'Orc Warrior',
     level: 5,
     health: 30,
-    imageUrl: "imgs/orcWarriorImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Frost Spider",
+    name: 'Frost Spider',
     level: 6,
     health: 16,
-    imageUrl: "imgs/frostSpiderImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   }];
 export const mediumMonsters = [
   {
-    name: "Fanged Beast",
+    name: 'Fanged Beast',
     level: 1,
     health: 60,
     power: 13,
-    imageUrl: "imgs/fangedBeast.png"
+    imageUrl: 'imgs/fangedBeast.png'
   },
   {
-    name: "Arcane Golem",
+    name: 'Arcane Golem',
     level: 1,
     health: 38,
     power: 18,
-    imageUrl: "imgs/arcaneGolem.png"
+    imageUrl: 'imgs/arcaneGolem.png'
   },
   {
-    name: "Spectral Assassin",
+    name: 'Spectral Assassin',
     level: 1,
     health: 50,
     power: 15,
-    imageUrl: "imgs/spectralAssassin.png"
+    imageUrl: 'imgs/spectralAssassin.png'
   },
   {
-    name: "Lava Beast",
+    name: 'Lava Beast',
     level: 2,
     health: 40,
-    imageUrl: "imgs/lavaBeastImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Swamp Lurker",
+    name: 'Swamp Lurker',
     level: 2,
     health: 33,
-    imageUrl: "imgs/swampLurkerImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Frost Giant",
+    name: 'Frost Giant',
     level: 2,
     health: 50,
-    imageUrl: "imgs/frostGiantImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Dune Scorpion",
+    name: 'Dune Scorpion',
     level: 3,
     health: 26,
-    imageUrl: "imgs/duneScorpionImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Crystal Dragon",
+    name: 'Crystal Dragon',
     level: 3,
     health: 45,
-    imageUrl: "imgs/crystalDragonImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Mystic Witch",
+    name: 'Mystic Witch',
     level: 3,
     health: 24,
-    imageUrl: "imgs/mysticWitchImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Thunder Griffin",
+    name: 'Thunder Griffin',
     level: 4,
     health: 33,
-    imageUrl: "imgs/thunderGriffinImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Cave Troll",
+    name: 'Cave Troll',
     level: 4,
     health: 50,
-    imageUrl: "imgs/caveTrollImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Fire Elemental",
+    name: 'Fire Elemental',
     level: 4,
     health: 25,
-    imageUrl: "imgs/fireElementalImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Ice Wraith",
+    name: 'Ice Wraith',
     level: 5,
     health: 22,
-    imageUrl: "imgs/iceWraithImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Shadow Fiend",
+    name: 'Shadow Fiend',
     level: 5,
     health: 35,
-    imageUrl: "imgs/shadowFiendImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Rock Golem",
+    name: 'Rock Golem',
     level: 5,
     health: 40,
-    imageUrl: "imgs/rockGolemImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   },
   {
-    name: "Necromancer",
+    name: 'Necromancer',
     level: 6,
     health: 18,
-    imageUrl: "imgs/necromancerImage.png"
+    imageUrl: 'imgs/placeholder-monster.svg'
   }];
-  export const bossMonsters = [
-    {
-      name: "Dragon",
-      level: 5,
-      health: 300,
-      imageUrl: "imgs/bossDragon.png"
-    },
-    {
-      name: "Shadow Empress",
-      level: 2,
-      health: 125,
-      imageUrl: "imgs/shadowEmpressImage.png"
-    },
-    {
-      name: "Solar Phoenix",
-      level: 3,
-      health: 115,
-      imageUrl: "imgs/solarPhoenixImage.png"
-    },
-    {
-      name: "Netherworld Banshee",
-      level: 4,
-      health: 90,
-      imageUrl: "imgs/netherworldBansheeImage.png"
-    },
-    {
-      name: "Giant Stone Guardian",
-      level: 5,
-      health: 120,
-      imageUrl: "imgs/giantStoneGuardianImage.png"
-    },
-    {
-      name: "Stormbringer Wyrm",
-      level: 13,
-      health: 95,
-      imageUrl: "imgs/stormbringerWyrmImage.png"
-    },
-    {
-      name: "Titan of the Depths",
-      level: 14,
-      health: 105,
-      imageUrl: "imgs/titanOfTheDepthsImage.png"
-    },
-    {
-      name: "Inferno Dragon",
-      level: 15,
-      health: 110,
-      imageUrl: "imgs/infernoDragonImage.png"
-    },
-    {
-      name: "Eternal Lich",
-      level: 16,
-      health: 130,
-      imageUrl: "imgs/eternalLichImage.png"
-    },
-    {
-      name: "Abyssal Overlord",
-      level: 15,
-      health: 120,
-      imageUrl: "imgs/abyssalOverlordImage.png"
-    },
-    {
-      name: "Celestial Seraph",
-      level: 14,
-      health: 100,
-      imageUrl: "imgs/celestialSeraphImage.png"
-    }];
+export const bossMonsters = [
+  {
+    name: 'Dragon',
+    level: 5,
+    health: 300,
+    imageUrl: 'imgs/bossDragon.png'
+  },
+  {
+    name: 'Shadow Empress',
+    level: 2,
+    health: 125,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Solar Phoenix',
+    level: 3,
+    health: 115,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Netherworld Banshee',
+    level: 4,
+    health: 90,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Giant Stone Guardian',
+    level: 5,
+    health: 120,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Stormbringer Wyrm',
+    level: 13,
+    health: 95,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Titan of the Depths',
+    level: 14,
+    health: 105,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Inferno Dragon',
+    level: 15,
+    health: 110,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Eternal Lich',
+    level: 16,
+    health: 130,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Abyssal Overlord',
+    level: 15,
+    health: 120,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  },
+  {
+    name: 'Celestial Seraph',
+    level: 14,
+    health: 100,
+    imageUrl: 'imgs/placeholder-monster.svg'
+  }
+];
 
 function addDefaultDefense(monsters) {
   monsters.forEach(monster => {
@@ -277,3 +278,4 @@ function addDefaultDefense(monsters) {
 addDefaultDefense(smallMonsters);
 addDefaultDefense(mediumMonsters);
 addDefaultDefense(bossMonsters);
+


### PR DESCRIPTION
## Summary
- add SVG placeholder for monsters without artwork
- update monster data to point missing image paths to the placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4bc9697ec832f961a4ee91c066a05