### PR TITLE
Handle zero agility in hit calculation

### DIFF
--- a/USERMANUAL.md
+++ b/USERMANUAL.md
@@ -41,8 +41,8 @@ In the cave you can fight **small** or **medium** monsters. The **Fight Boss** b
 hub starts a battle with a boss.
 
 During combat:
-- **Attack**: damage the enemy based on your strength and weapon. Attacks can miss if the
-  enemy's agility is higher than yours.
+ - **Attack**: damage the enemy based on your strength and weapon. Attacks can miss if the
+   enemy's agility is higher than yours or if both combatants have no agility.
 - **Use Item**: consumes a health potion if you have one in your inventory.
 - **Run**: flee back to the town square.
 - Defeating monsters grants gold and experience. When experience reaches the requirement

--- a/fight.js
+++ b/fight.js
@@ -160,9 +160,16 @@ function getPlayerAttackValue() {
 }
 
 function doesHit(attackerAgility, defenderAgility) {
-  let hitChance = attackerAgility / (attackerAgility + defenderAgility);
+  // Avoid division by zero or negative agility totals.
+  const totalAgility = attackerAgility + defenderAgility;
+  if (totalAgility <= 0) {
+    return false;
+  }
+  const hitChance = attackerAgility / totalAgility;
   return Math.random() < hitChance;
 }
+
+export { doesHit };
   
 /**
  * Handles using an item during a fight.

--- a/tests/hitChance.test.js
+++ b/tests/hitChance.test.js
@@ -1,0 +1,44 @@
+let doesHit;
+
+beforeAll(async () => {
+  document.body.innerHTML = `
+    <div id='controls'></div>
+    <div id='text'></div>
+    <div id='xpText'></div>
+    <div id='healthText'></div>
+    <div id='goldText'></div>
+    <div id='image'></div>
+    <div id='monsterName'></div>
+    <div id='monsterHealth'></div>
+    <div id='monsterText'></div>
+    <div id='monsterHealthStat'></div>
+    <div id='levelText'></div>
+    <div id='monsterStats'></div>
+    <div id='imageContainer'></div>
+    <div id='characterPreview'></div>
+    <div id='xpBarFill'></div>
+  `;
+  ({ doesHit } = await import('../fight.js'));
+});
+
+describe('doesHit', () => {
+  let realRandom;
+
+  beforeEach(() => {
+    realRandom = Math.random;
+  });
+
+  afterEach(() => {
+    Math.random = realRandom;
+  });
+
+  test('returns false when both combatants have zero agility', () => {
+    Math.random = () => 0.5;
+    expect(doesHit(0, 0)).toBe(false);
+  });
+
+  test('calculates hit when defender has zero agility', () => {
+    Math.random = () => 0.5;
+    expect(doesHit(10, 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent division by zero in `doesHit` by returning false when combined agility is non-positive
- document that attacks fail when both combatants lack agility
- add tests covering zero-agility edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c8383a20832f884b53a48115ba48