### PR TITLE
Remove direct gold UI update in defeatMonster

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -198,11 +198,9 @@ eventEmitter.on('useItem', () => {
 */
 function defeatMonster() {
   let goldReward = Math.floor(fighting.level * 6.7);
-  let gold = player.getComponent('gold');
   eventEmitter.emit('addGold', goldReward);
   const xpReward = Math.ceil(fighting.level * 5);
   eventEmitter.emit('addXp', xpReward);
-  goldText.innerText = gold.gold;
   clearEnemy();
   eventEmitter.emit('update', locations[4]);
 }


### PR DESCRIPTION
## Summary
- Clean up monster defeat logic to rely on `addGold` event for updating gold display.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c82c72bc832faa6b2ce262403eda