### PR TITLE
Streamline weapon downgrade messaging

### DIFF
--- a/script.js
+++ b/script.js
@@ -318,11 +318,6 @@ eventEmitter.on('weaponDown',() => {
   if (inventory.length > 1 && weaponComp.weaponIndex > 0) {
     inventory.pop();
     weaponComp.weaponIndex--;
-    let newWeapon = weapons[weaponComp.weaponIndex].name;
-    text.innerText = 'You now have a ' + newWeapon + '.';
-    text.innerText += ' In your inventory you have: ' + inventory.join(', ');
-  } else {
-    text.innerText = 'You can\'t downgrade your weapon.';
   }
 });
 eventEmitter.on('armorUp', () => {

--- a/store.js
+++ b/store.js
@@ -94,15 +94,18 @@ export function buyAccessory(index) {
 /**
  * Sells the most recently acquired weapon, adds its gold value,
  * downgrades the current weapon and updates the player text with
- * the sold weapon name and remaining inventory.
- */
+ * the sold weapon name, new weapon and remaining inventory.
+*/
 export function sellWeapon() {
   let inventory = player.getComponent('inventory').items.weapons;
   if (inventory.length > 1) {
+    let weaponComp = player.getComponent('currentWeapon');
     let soldWeapon = inventory[inventory.length - 1];
     eventEmitter.emit('addGold', 20);
     eventEmitter.emit('weaponDown');
+    let currentWeapon = weapons[weaponComp.weaponIndex].name;
     text.innerText = 'You sold a ' + soldWeapon + '.';
+    text.innerText += ' You now have a ' + currentWeapon + '.';
     text.innerText += ' In your inventory you have: ' + inventory.join(', ');
   } else {
     text.innerText = "Don't sell your only weapon!";

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -1,6 +1,9 @@
 let buyArmor;
+let buyWeapon;
+let sellWeapon;
 let player;
 let armor;
+let weapons;
 
 beforeAll(async () => {
   document.body.innerHTML = `
@@ -15,9 +18,9 @@ beforeAll(async () => {
     <div id='characterPreview'></div>
     <div id='xpBarFill'></div>
   `;
-  ({ buyArmor } = await import('../store.js'));
+  ({ buyArmor, buyWeapon, sellWeapon } = await import('../store.js'));
   ({ player } = await import('../script.js'));
-  ({ armor } = await import('../item.js'));
+  ({ armor, weapons } = await import('../item.js'));
 });
 
 beforeEach(() => {
@@ -26,6 +29,9 @@ beforeEach(() => {
   const armorComp = player.getComponent('currentArmor');
   armorComp.armorIndex = -1;
   player.getComponent('inventory').items.armor = [];
+  const weaponComp = player.getComponent('currentWeapon');
+  weaponComp.weaponIndex = 0;
+  player.getComponent('inventory').items.weapons = [weapons[0].name];
 });
 
 test('buyArmor purchases next armor and subtracts gold', () => {
@@ -36,5 +42,14 @@ test('buyArmor purchases next armor and subtracts gold', () => {
   expect(goldComp.gold).toBe(60);
   expect(armorComp.armorIndex).toBe(0);
   expect(inventory[0]).toBe(armor[0].name);
+});
+
+test('sellWeapon downgrades weapon and updates inventory', () => {
+  buyWeapon();
+  sellWeapon();
+  const weaponComp = player.getComponent('currentWeapon');
+  const inventory = player.getComponent('inventory').items.weapons;
+  expect(weaponComp.weaponIndex).toBe(0);
+  expect(inventory).toEqual([weapons[0].name]);
 });
 


### PR DESCRIPTION
## Summary
- Remove UI messaging from `weaponDown` listener to keep game text centralized
- Announce sold and current weapon within `sellWeapon` to handle all player-facing messages
- Add regression test ensuring selling downgrades weapon and updates inventory correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c51ab8d7fc832f8d0c421f3ae8138c