### PR TITLE
fix: avoid undefined fight image

### DIFF
--- a/location.js
+++ b/location.js
@@ -311,12 +311,14 @@ eventEmitter.on('update', (location) => {
     characterPreview.src = '';
   }
   if (location.image === false) {
-    imageContainer.style.display = "none";
-    image.style.display = "none";
+    imageContainer.style.display = 'none';
+    image.style.display = 'none';
   } else if (location.image === true) {
-    imageContainer.style.display = "block";
-    image.style.display = "block";
-    image.src = getImageUrl(location.imageUrl);
+    imageContainer.style.display = 'block';
+    image.style.display = 'block';
+    if (location.imageUrl) {
+      image.src = getImageUrl(location.imageUrl);
+    }
   }
     if (location.name === 'fight') {
       monsterStats.style.display = "block";


### PR DESCRIPTION
## Summary
- only set image src when location.imageUrl exists

## Testing
- `npm test`
- `node --input-type=module <script>` simulation of fight image src


------
https://chatgpt.com/codex/tasks/task_e_68c51ddcc78c832f90a64ca3744ea22a