### PR TITLE
Support max health in player templates

### DIFF
--- a/USERMANUAL.md
+++ b/USERMANUAL.md
@@ -11,7 +11,7 @@ This manual explains every screen and mechanic so you can jump in and start adve
 ## Home Screen
 - **Start**: enter the world.
 - **Pick Character**: select a template such as warrior or mage. Each template changes your
-  starting stats and portrait.
+  starting stats (including current and maximum health) and portrait.
 - **Settings**: adjust audio and other preferences.
 - **Changelog**: view recent updates.
 

--- a/playerTemplate.js
+++ b/playerTemplate.js
@@ -6,7 +6,7 @@ export const characterTemplates = [
   {
     name: 'Warrior',
     imageUrl: 'imgs/warrior.png',
-    health: { currentHealth: 150 },
+    health: { currentHealth: 150, maxHealth: 150 },
     strength: { strength: 20 },
     defense: { defense: 10 },
     agility: { agility: 10 },
@@ -25,7 +25,7 @@ export const characterTemplates = [
   {
     name: 'Wizard',
     imageUrl: 'imgs/wizard.png',
-    health: { currentHealth: 80 },
+    health: { currentHealth: 80, maxHealth: 80 },
     strength: { strength: 5 },
     defense: { defense: 5 },
     agility: { agility: 12 },
@@ -44,7 +44,7 @@ export const characterTemplates = [
   {
     name: 'Rogue',
     imageUrl: 'imgs/rogue.png',
-    health: { currentHealth: 100 },
+    health: { currentHealth: 100, maxHealth: 100 },
     strength: { strength: 15 },
     defense: { defense: 8 },
     agility: { agility: 18 },

--- a/script.js
+++ b/script.js
@@ -135,8 +135,16 @@ export function initializePlayer(template) {
   }
   if (template.health) {
     const healthComp = player.getComponent('health');
-    healthComp.currentHealth = template.health.currentHealth;
-    healthComp.maxHealth = template.health.currentHealth;
+    // Use template maxHealth when available; otherwise default to currentHealth.
+    const maxHealth =
+      template.health.maxHealth ?? template.health.currentHealth;
+    // Clamp provided currentHealth to the calculated maxHealth.
+    const currentHealth = Math.min(
+      template.health.currentHealth ?? maxHealth,
+      maxHealth
+    );
+    healthComp.maxHealth = maxHealth;
+    healthComp.currentHealth = currentHealth;
     healthText.innerText = healthComp.currentHealth;
   }
   if (template.strength) {

--- a/tests/playerInitialization.test.js
+++ b/tests/playerInitialization.test.js
@@ -1,0 +1,41 @@
+let initializePlayer;
+let player;
+
+beforeAll(async () => {
+  document.body.innerHTML = `
+    <div id='text'></div>
+    <div id='xpText'></div>
+    <div id='healthText'></div>
+    <div id='goldText'></div>
+    <div id='image'></div>
+    <div id='levelText'></div>
+    <div id='monsterStats'></div>
+    <div id='imageContainer'></div>
+    <div id='characterPreview'></div>
+    <div id='xpBarFill'></div>
+  `;
+  ({ initializePlayer, player } = await import('../script.js'));
+});
+
+beforeEach(() => {
+  const healthComp = player.getComponent('health');
+  healthComp.currentHealth = 100;
+  healthComp.maxHealth = 100;
+});
+
+test('initializePlayer uses maxHealth when provided', () => {
+  const template = { health: { currentHealth: 50, maxHealth: 120 } };
+  initializePlayer(template);
+  const healthComp = player.getComponent('health');
+  expect(healthComp.maxHealth).toBe(120);
+  expect(healthComp.currentHealth).toBe(50);
+});
+
+test('initializePlayer clamps current health to maxHealth', () => {
+  const template = { health: { currentHealth: 150, maxHealth: 100 } };
+  initializePlayer(template);
+  const healthComp = player.getComponent('health');
+  expect(healthComp.maxHealth).toBe(100);
+  expect(healthComp.currentHealth).toBe(100);
+});
+


### PR DESCRIPTION
## Summary
- allow initializePlayer to read template maxHealth and clamp current health
- update character templates with separate current and maximum health
- document character template health fields and test initialization behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c51e161854832fb4e057f8dc126911