### PR TITLE
Use update handler for monster stats panel

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -1,4 +1,4 @@
-import { locations, monsterHealthText, monsterNameText, monsterStats } from './location.js';
+import { locations, monsterHealthText, monsterNameText } from './location.js';
 import { weapons } from './item.js';
 import { eventEmitter } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
@@ -54,7 +54,6 @@ eventEmitter.on('goFight', () => {
   enemyHealth = enemy.getComponent('health');
   enemyName = enemy.getComponent('name');
   const enemyImageUrl = enemy.getComponent('imageUrl').imageUrl;
-  monsterStats.style.display = 'block';
   monsterNameText.innerText = enemyName.name;
   monsterHealthText.innerText = enemyHealth.currentHealth;
 

--- a/tests/monsterStatsVisibility.test.js
+++ b/tests/monsterStatsVisibility.test.js
@@ -1,0 +1,36 @@
+import { expect, test } from '@jest/globals';
+
+test('monster stats panel toggles on fight and town', async () => {
+  document.body.innerHTML = `
+    <div id='text'></div>
+    <div id='xpText'></div>
+    <div id='healthText'></div>
+    <div id='goldText'></div>
+    <img id='image'/>
+    <div id='levelText'></div>
+    <div id='monsterStats' style='display: none;'></div>
+    <div id='imageContainer'></div>
+    <img id='characterPreview'/>
+    <div id='xpBarFill'></div>
+    <div id='monsterName'></div>
+    <div id='monsterHealth'></div>
+    <div id='monsterText'></div>
+    <div id='monsterHealthStat'></div>
+    <div id='controls'></div>
+  `;
+
+  const { eventEmitter } = await import('../eventEmitter.js');
+  const locationModule = await import('../location.js');
+  await import('../fight.js');
+
+  const { goTown, monsterStats } = locationModule;
+
+  expect(monsterStats.style.display).toBe('none');
+
+  eventEmitter.emit('fightSmall');
+  expect(monsterStats.style.display).toBe('block');
+
+  goTown();
+  expect(monsterStats.style.display).toBe('none');
+});
+


### PR DESCRIPTION
## Summary
- stop `goFight` from manually showing monster stats
- rely on location update handler to toggle stats panel
- cover stats panel visibility with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c594edd4b4832fb9c6c13d275d02d2