### PR TITLE
Prevent negative gold balance

### DIFF
--- a/USERMANUAL.md
+++ b/USERMANUAL.md
@@ -32,6 +32,7 @@ The store offers goods and services:
 - **Buy accessories**: each accessory gives permanent bonuses such as extra health or
   strength.
 - **Sell Weapon**: sells your most recently acquired weapon for 20 gold.
+- Spending more gold than you have reduces your balance to zero; it never goes negative.
 - **Go to town square**: return to the hub.
 
 Item buttons display icons for easier browsing.

--- a/script.js
+++ b/script.js
@@ -302,7 +302,7 @@ eventEmitter.on('addGold', (amount) => {
 });
 eventEmitter.on('subtractGold', (amount) => {
   let goldComp = player.getComponent('gold');
-  goldComp.gold -= amount;
+  goldComp.gold = Math.max(0, goldComp.gold - amount);
   goldText.innerText = goldComp.gold;
 });
 

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -4,6 +4,7 @@ let sellWeapon;
 let player;
 let armor;
 let weapons;
+let eventEmitter;
 
 beforeAll(async () => {
   document.body.innerHTML = `
@@ -21,6 +22,7 @@ beforeAll(async () => {
   ({ buyArmor, buyWeapon, sellWeapon } = await import('../store.js'));
   ({ player } = await import('../script.js'));
   ({ armor, weapons } = await import('../item.js'));
+  ({ eventEmitter } = await import('../eventEmitter.js'));
 });
 
 beforeEach(() => {
@@ -51,5 +53,12 @@ test('sellWeapon downgrades weapon and updates inventory', () => {
   const inventory = player.getComponent('inventory').items.weapons;
   expect(weaponComp.weaponIndex).toBe(0);
   expect(inventory).toEqual([weapons[0].name]);
+});
+
+test('subtracting more gold than available sets balance to zero', () => {
+  const goldComp = player.getComponent('gold');
+  goldComp.gold = 20;
+  eventEmitter.emit('subtractGold', 50);
+  expect(goldComp.gold).toBe(0);
 });
 


### PR DESCRIPTION
## Summary
- Clamp gold deductions at zero to avoid negative gold totals
- Document that overspending leaves gold at zero
- Add unit test ensuring subtractGold caps balance at zero

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c599509774832f92465c7052b0d342