### PR TITLE
Remove unused goldText import from fight.js

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -2,7 +2,7 @@ import { locations, monsterHealthText, monsterNameText } from './location.js';
 import { weapons } from './item.js';
 import { eventEmitter } from './eventEmitter.js';
 import { smallMonsters, mediumMonsters, bossMonsters } from './monster.js';
-import { player, entityManager, text, goldText, image } from './script.js';
+import { player, entityManager, text, image } from './script.js';
 import {
   nameComponent,
   healthComponent,


### PR DESCRIPTION
## Summary
- remove goldText import from fight.js
- tidy up unused references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5994f2308832f9c9830aaf99ea3fd