### PR TITLE
Clear enemy before starting new fight

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -41,6 +41,10 @@ function clearEnemy() {
 }
 
 eventEmitter.on('goFight', () => {
+  if (enemy) {
+    return;
+  }
+  clearEnemy();
   eventEmitter.emit('update', locations[3]);
   enemy = entityManager.createEntity({
     name: new nameComponent(fighting.name),


### PR DESCRIPTION
## Summary
- Guard against starting a fight while one is active
- Clear any previous enemy before spawning a new one

## Testing
- `npm test`
- Repeatedly emitted `fightSmall` events and confirmed entity count stays at 2

------
https://chatgpt.com/codex/tasks/task_e_68c5b9875d3c832f8a0d21c5fa987fcb