### PR TITLE
Clarify monster attack damage and expand tests

### DIFF
--- a/fight.js
+++ b/fight.js
@@ -144,8 +144,8 @@ eventEmitter.on('fightBoss', () => {
 });
 
 /**
- * Calculates the attack damage value for a monster based on its level.
- * Subtracts a random value based on player XP to add variability.
+ * Calculates the monster's attack damage as a random integer
+ * between 0 (inclusive) and its strength (exclusive).
 */
 function getMonsterAttackValue() {
   let strengthComp = enemy.getComponent('strength');

--- a/tests/monsterAttack.test.js
+++ b/tests/monsterAttack.test.js
@@ -41,3 +41,26 @@ test('monster with zero strength deals no damage', () => {
   expect(healthComp.currentHealth).toBe(100);
   eventEmitter.emit('goTown');
 });
+
+test('monster damage scales with strength', () => {
+  const healthComp = player.getComponent('health');
+  healthComp.maxHealth = 100;
+  healthComp.currentHealth = 100;
+  const strengthComp = player.getComponent('strength');
+  strengthComp.strength = 0;
+  const agilityComp = player.getComponent('agility');
+  agilityComp.agility = 0;
+  eventEmitter.emit('fightSmall');
+  const enemyEntity = entityManager.entities.find(
+    e => e.getComponent('name').name !== 'player'
+  );
+  enemyEntity.getComponent('strength').strength = 10;
+  enemyEntity.getComponent('agility').agility = 10;
+  const realRandom = Math.random;
+  const randomValues = [0, 0.7, 0];
+  Math.random = () => randomValues.shift();
+  eventEmitter.emit('attack');
+  Math.random = realRandom;
+  expect(healthComp.currentHealth).toBe(93);
+  eventEmitter.emit('goTown');
+});


### PR DESCRIPTION
## Summary
- Clarify comment for `getMonsterAttackValue` to describe random damage based on strength
- Add test ensuring monster damage scales with strength

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5bc9a2168832fbc7d6c1f0dc84831