### PR TITLE
Handle extra button images gracefully

### DIFF
--- a/location.js
+++ b/location.js
@@ -246,11 +246,8 @@ function createButtons(location) {
       `Button text (${texts.length}) and functions (${functions.length}) length mismatch`
     );
   }
-  if (
-    Array.isArray(images) &&
-    (images.length !== texts.length || images.length !== functions.length)
-  ) {
-    console.warn(`Button images (${images.length}) length mismatch`);
+  if (Array.isArray(images) && images.length > limit) {
+    console.warn(`Extra button images (${images.length - limit}) ignored`);
   }
 
   for (let index = 0; index < limit; index++) {

--- a/tests/buttonImages.test.js
+++ b/tests/buttonImages.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 let goStore;
 let locations;
 let eventEmitter;
@@ -45,10 +46,13 @@ test('store buttons show matching icons', () => {
 test('missing button images do not remove buttons', () => {
   goStore();
   const store = locations.find(l => l.name === 'store');
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   store['button images'].pop();
   eventEmitter.emit('update', store);
   const buttons = document.querySelectorAll('#controls button');
   const texts = store['button text'];
   expect(buttons.length).toBe(texts.length);
+  expect(warnSpy).not.toHaveBeenCalled();
+  warnSpy.mockRestore();
 });
 


### PR DESCRIPTION
## Summary
- Avoid spurious warnings when fewer button images are provided than button labels.
- Add test coverage for missing button images without console warnings.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5dc8dd3e4832faaf9e3bebe059e56